### PR TITLE
Improve create/rename file dialog UX

### DIFF
--- a/src/app/dialogs/create-document-dialog/create-document-dialog.component.html
+++ b/src/app/dialogs/create-document-dialog/create-document-dialog.component.html
@@ -17,7 +17,7 @@
 <div mat-dialog-content class="dialog-content">
   <mat-form-field appearance="outline" class="document-name-field">
     <mat-label>{{ 'dialogs.createDocument.documentName' | translate }}</mat-label>
-    <input matInput [(ngModel)]="documentName" [placeholder]="getDefaultName()"
+    <input #nameInput matInput [(ngModel)]="documentName" [placeholder]="getDefaultName()"
       (keyup.enter)="onCreate()" autocomplete="off" [attr.aria-label]="'dialogs.createDocument.documentName' | translate"
       aria-required="true" cdkFocusInitial>
     <mat-icon matPrefix class="input-icon" aria-hidden="true">{{ getIcon() }}</mat-icon>

--- a/src/app/dialogs/create-document-dialog/create-document-dialog.component.ts
+++ b/src/app/dialogs/create-document-dialog/create-document-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, inject, OnInit, ViewChild } from '@angular/core';
 
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -35,8 +35,10 @@ export interface CreateDocumentDialogResult {
     A11yModule
   ],
 })
-export class CreateDocumentDialogComponent implements OnInit {
+export class CreateDocumentDialogComponent implements OnInit, AfterViewInit {
   documentName = '';
+
+  @ViewChild('nameInput') nameInput!: ElementRef<HTMLInputElement>;
 
   readonly dialogRef = inject(MatDialogRef<CreateDocumentDialogComponent>);
   readonly data = inject<CreateDocumentDialogData>(MAT_DIALOG_DATA);
@@ -44,6 +46,21 @@ export class CreateDocumentDialogComponent implements OnInit {
   ngOnInit() {
     // Set default name based on document type
     this.documentName = this.getDefaultName();
+  }
+
+  ngAfterViewInit() {
+    // Select only the filename part (before extension) so user can type a name immediately
+    setTimeout(() => {
+      const input = this.nameInput?.nativeElement;
+      if (input) {
+        const dotIndex = this.documentName.lastIndexOf('.');
+        if (dotIndex > 0) {
+          input.setSelectionRange(0, dotIndex);
+        } else {
+          input.select();
+        }
+      }
+    });
   }
 
   getDefaultName(): string {

--- a/src/app/dialogs/rename-dialog/rename-dialog.component.html
+++ b/src/app/dialogs/rename-dialog/rename-dialog.component.html
@@ -18,7 +18,7 @@
   <mat-form-field appearance="outline" class="folder-name-field">
     <mat-label>{{ (data.type === 'FOLDER' ? 'dialogs.rename.folderName' : 'dialogs.rename.fileName') | translate
       }}</mat-label>
-    <input matInput [(ngModel)]="newName" [placeholder]="'dialogs.rename.placeholder' | translate"
+    <input #nameInput matInput [(ngModel)]="newName" [placeholder]="'dialogs.rename.placeholder' | translate"
       (keyup.enter)="onRename()" autocomplete="off"
       [attr.aria-label]="(data.type === 'FOLDER' ? 'dialogs.rename.folderName' : 'dialogs.rename.fileName') | translate"
       aria-required="true" cdkFocusInitial>

--- a/src/app/dialogs/rename-dialog/rename-dialog.component.ts
+++ b/src/app/dialogs/rename-dialog/rename-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, inject, ViewChild } from '@angular/core';
 
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -30,14 +30,36 @@ export interface RenameDialogData {
     A11yModule
 ],
 })
-export class RenameDialogComponent {
+export class RenameDialogComponent implements AfterViewInit {
   newName: string;
+
+  @ViewChild('nameInput') nameInput!: ElementRef<HTMLInputElement>;
 
   readonly dialogRef = inject(MatDialogRef<RenameDialogComponent>);
   readonly data = inject<RenameDialogData>(MAT_DIALOG_DATA);
 
   constructor() {
     this.newName = this.data.name;
+  }
+
+  ngAfterViewInit() {
+    // For files, select only the filename part (before extension) so user can rename without losing the extension
+    // For folders, select the entire name
+    setTimeout(() => {
+      const input = this.nameInput?.nativeElement;
+      if (input) {
+        if (this.data.type === 'FILE') {
+          const dotIndex = this.newName.lastIndexOf('.');
+          if (dotIndex > 0) {
+            input.setSelectionRange(0, dotIndex);
+          } else {
+            input.select();
+          }
+        } else {
+          input.select();
+        }
+      }
+    });
   }
 
   onRename() {


### PR DESCRIPTION
## Summary
- Auto-select only the filename part (before extension) in create document and rename file dialogs
- Users can immediately type a new name without losing the file extension
- Matches standard OS behavior (Windows Explorer, macOS Finder)
- Folders get fully selected since they have no extension

## Test plan
- [ ] Create a new Word/Excel/PPT/Text document — verify only the name part is selected, not the extension
- [ ] Rename a file — verify only the name part is selected
- [ ] Rename a folder — verify the entire name is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)