### PR TITLE
Fix Node.js 20 deprecation warnings and glob override

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
   },
   "overrides": {
     "dompurify": "3.3.3",
-    "undici": "7.24.4"
+    "undici": "7.24.4",
+    "@ngx-env/builder": {
+      "glob": "13.0.6"
+    }
   },
   "devDependencies": {
     "@angular/build": "~21.2.3",


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions (`checkout` v6, `setup-node` v6, `create-github-app-token` v3) to Node 24
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var for `softprops/action-gh-release@v2` (no v3 available yet)
- Replace unmaintained `devmasx/merge-branch` action with plain git commands
- Override `@ngx-env/builder` glob dependency to `13.0.6` to resolve deprecation warning

## Test plan
- [ ] Verify CI workflow runs without Node.js 20 deprecation warnings
- [ ] Verify `npm install` produces no glob deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)