### PR TITLE
Fix merge main->develop in CI workflow

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Merge main -> develop
         run: |
-          git fetch origin develop
+          git fetch --unshallow origin
           git checkout develop
           git merge main --no-edit
           git push origin develop


### PR DESCRIPTION
## Summary
- Fix "refusing to merge unrelated histories" error in release workflow
- Use `git fetch --unshallow origin` before merging main into develop to ensure full history is available

## Test plan
- [ ] Run release workflow and verify the merge main→develop step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)