### PR TITLE
fix(file-viewer): hide Print button in OnlyOffice mode

### DIFF
--- a/src/app/dialogs/file-viewer-dialog/file-viewer-dialog.component.html
+++ b/src/app/dialogs/file-viewer-dialog/file-viewer-dialog.component.html
@@ -66,10 +66,17 @@
       </button>
       }
 
-      <!-- Print -->
+      <!-- Print
+           Hidden for OnlyOffice: the document is rendered inside a cross-origin
+           OnlyOffice iframe, so window.print() can only reach the OpenFilz shell
+           (it would print the toolbar/blank page, not the document). OnlyOffice
+           exposes no API to trigger its own print, so users print from the editor's
+           built-in Print control / Ctrl+P, which prints just the document. -->
+      @if (viewerMode !== 'onlyoffice') {
       <button mat-icon-button (click)="print()" [matTooltip]="'fileViewer.print' | translate">
         <mat-icon>print</mat-icon>
       </button>
+      }
 
       <!-- Fullscreen Toggle -->
       <button mat-icon-button (click)="toggleFullscreen()"

--- a/src/app/dialogs/file-viewer-dialog/file-viewer-dialog.component.ts
+++ b/src/app/dialogs/file-viewer-dialog/file-viewer-dialog.component.ts
@@ -484,6 +484,15 @@ export class FileViewerDialogComponent implements OnInit, AfterViewInit, OnDestr
   }
 
   print() {
+    // OnlyOffice renders the document in a cross-origin iframe that window.print()
+    // cannot reach — it would print the OpenFilz shell instead of the document.
+    // OnlyOffice has no API to trigger its own print, so we rely on the editor's
+    // built-in Print control / Ctrl+P (and the header Print button is hidden in
+    // OnlyOffice mode). For every other viewer mode window.print() prints the
+    // rendered content (toolbar is hidden via the @media print styles).
+    if (this.viewerMode === 'onlyoffice') {
+      return;
+    }
     window.print();
   }
 


### PR DESCRIPTION
window.print() can only reach the OpenFilz shell, not the cross-origin OnlyOffice iframe, so it printed the toolbar/blank page instead of the document. OnlyOffice exposes no API to trigger its own print, so hide the header Print button in OnlyOffice mode and let users print from the editor's built-in Print control / Ctrl+P (which prints just the document). Other viewer modes are unchanged (toolbar hidden via @media print).