### PR TITLE
feat(explorer): quick file-type filter icon in the folder toolbar

### DIFF
--- a/src/app/components/file-explorer/file-explorer.component.ts
+++ b/src/app/components/file-explorer/file-explorer.component.ts
@@ -97,6 +97,9 @@ type FolderConflictItem = BatchConflictItem & { parentId?: string };
         [sortBy]="sortBy"
         [sortOrder]="sortOrder"
         (sortChange)="onSortChange($event)"
+        [showTypeFilter]="true"
+        [activeFileType]="currentFilters?.fileType || 'any'"
+        (fileTypeFilterChange)="onFileTypeFilterChange($event)"
       >
 
         <!-- Breadcrumb projected into toolbar for mobile visibility -->
@@ -894,6 +897,20 @@ export class FileExplorerComponent extends FileOperationsComponent implements On
       owner: '',
       fileType: 'any',
       metadata: [],
+      scope: 'CURRENT_ONLY'
+    });
+  }
+
+  /**
+   * Quick file-type filter from the toolbar icon. Preserves any other active filters
+   * (owner, date, metadata) and always scopes to the current folder so the view is
+   * filtered in place rather than routed to the search results page.
+   */
+  onFileTypeFilterChange(fileType: string) {
+    const current = this.searchService.getCurrentFilters();
+    this.searchService.updateFilters({
+      ...current,
+      fileType,
       scope: 'CURRENT_ONLY'
     });
   }

--- a/src/app/components/search-filters/search-filters.component.ts
+++ b/src/app/components/search-filters/search-filters.component.ts
@@ -6,6 +6,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DocumentType, SearchFilters, SearchScope } from '../../models/document.models';
+import { ANY_FILE_TYPE, FILE_TYPE_CATEGORIES } from '../../models/file-type-filters';
 
 @Component({
   selector: 'app-search-filters',
@@ -74,12 +75,12 @@ export class SearchFiltersComponent implements OnInit {
     { labelKey: 'searchFilters.dateOptions.last30', value: 'last30' }
   ];
 
+  // File-type options are sourced from the shared category definitions so the advanced
+  // dialog and the toolbar quick-filter stay in sync. Values are category ids (e.g. 'word'),
+  // resolved to content-type LIKE patterns in DocumentApiService.
   fileTypeOptions = [
-    { labelKey: 'searchFilters.fileTypeOptions.any', value: 'any' },
-    { labelKey: 'searchFilters.fileTypeOptions.pdfs', value: 'application/pdf' },
-    { labelKey: 'searchFilters.fileTypeOptions.images', value: 'image/' },
-    { labelKey: 'searchFilters.fileTypeOptions.documents', value: 'application/msword' },
-    { labelKey: 'searchFilters.fileTypeOptions.spreadsheets', value: 'application/vnd.ms-excel' }
+    { labelKey: 'searchFilters.fileTypeOptions.any', value: ANY_FILE_TYPE },
+    ...FILE_TYPE_CATEGORIES.map(c => ({ labelKey: c.labelKey, value: c.id }))
   ];
 
   scopeOptions: { labelKey: string; value: SearchScope }[] = [

--- a/src/app/components/toolbar/toolbar.component.css
+++ b/src/app/components/toolbar/toolbar.component.css
@@ -1715,3 +1715,59 @@
 :host-context(.theme-midnight) .page-size-btn:hover {
   background-color: rgba(255, 255, 255, 0.15);
 }
+
+/* ===== Quick file-type filter ===== */
+.type-filter-btn {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  color: var(--text-secondary);
+  border-radius: 10px;
+  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.type-filter-btn:hover {
+  background-color: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.type-filter-btn.active {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--primary) 15%, transparent) 0%,
+    color-mix(in srgb, var(--primary) 8%, transparent) 100%
+  );
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--primary) 20%, transparent);
+}
+
+/* Small accent dot to signal an active filter at a glance */
+.type-filter-dot {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--primary);
+  border: 2px solid var(--bg-primary);
+  box-sizing: content-box;
+}
+
+/* File-type menu items: label + trailing check aligned right */
+::ng-deep .file-type-menu .file-type-option.mat-mdc-menu-item {
+  display: flex;
+  align-items: center;
+}
+
+::ng-deep .file-type-menu .file-type-option .option-check {
+  margin-left: auto;
+  color: var(--primary);
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+::ng-deep .file-type-menu .file-type-option.active span {
+  font-weight: 600;
+  color: var(--primary);
+}

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -179,6 +179,42 @@
   }
 
   <div class="toolbar-right">
+    <!-- Quick file-type filter (folder view only) -->
+    @if(showTypeFilter) {
+    <button mat-icon-button class="type-filter-btn" [class.active]="hasTypeFilter"
+      [matMenuTriggerFor]="fileTypeMenu"
+      [matTooltip]="(hasTypeFilter ? (activeCategory!.labelKey | translate) : ('toolbar.filterByType' | translate))"
+      [attr.aria-label]="'toolbar.filterByType' | translate" aria-haspopup="menu">
+      @if(activeCategory) {
+      <mat-icon aria-hidden="true" [style.color]="activeCategory.color">{{ activeCategory.icon }}</mat-icon>
+      <span class="type-filter-dot" aria-hidden="true"></span>
+      } @else {
+      <mat-icon aria-hidden="true">filter_alt</mat-icon>
+      }
+    </button>
+    <mat-menu #fileTypeMenu="matMenu" class="file-type-menu">
+      <button mat-menu-item class="file-type-option" (click)="onFileTypeSelected(ANY_FILE_TYPE)"
+        [class.active]="!hasTypeFilter">
+        <mat-icon aria-hidden="true">apps</mat-icon>
+        <span>{{ 'searchFilters.fileTypeOptions.any' | translate }}</span>
+        @if(!hasTypeFilter) {
+        <mat-icon class="option-check" aria-hidden="true">check</mat-icon>
+        }
+      </button>
+      <mat-divider></mat-divider>
+      @for(cat of fileTypeCategories; track cat.id) {
+      <button mat-menu-item class="file-type-option" (click)="onFileTypeSelected(cat.id)"
+        [class.active]="activeFileType === cat.id">
+        <mat-icon aria-hidden="true" [style.color]="cat.color">{{ cat.icon }}</mat-icon>
+        <span>{{ cat.labelKey | translate }}</span>
+        @if(activeFileType === cat.id) {
+        <mat-icon class="option-check" aria-hidden="true">check</mat-icon>
+        }
+      </button>
+      }
+    </mat-menu>
+    }
+
     <!-- View toggle - always visible -->
     <div class="view-toggle" role="group" aria-label="View mode toggle">
       <button mat-icon-button [class.active]="viewMode === 'grid'" (click)="viewMode !== 'grid' && toggleViewMode()"

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -9,6 +9,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { AppConfig } from '../../config/app.config';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DocumentTemplateType } from '../../models/document.models';
+import { ANY_FILE_TYPE, FILE_TYPE_CATEGORIES, FileTypeCategory, getFileTypeCategory } from '../../models/file-type-filters';
 
 @Component({
   selector: 'app-toolbar',
@@ -62,6 +63,26 @@ export class ToolbarComponent {
 
   @Input() sortBy = 'name';
   @Input() sortOrder: 'ASC' | 'DESC' = 'ASC';
+
+  // Quick file-type filter (folder view only)
+  @Input() showTypeFilter = false;
+  @Input() activeFileType: string = ANY_FILE_TYPE;
+  @Output() fileTypeFilterChange = new EventEmitter<string>();
+
+  readonly fileTypeCategories = FILE_TYPE_CATEGORIES;
+  readonly ANY_FILE_TYPE = ANY_FILE_TYPE;
+
+  get activeCategory(): FileTypeCategory | undefined {
+    return getFileTypeCategory(this.activeFileType);
+  }
+
+  get hasTypeFilter(): boolean {
+    return !!this.activeCategory;
+  }
+
+  onFileTypeSelected(fileType: string): void {
+    this.fileTypeFilterChange.emit(fileType);
+  }
 
   sortOptions = [
     { labelKey: 'common.name', value: 'name' },

--- a/src/app/models/document.models.ts
+++ b/src/app/models/document.models.ts
@@ -231,6 +231,8 @@ export interface ListFolderRequest {
   id?: string;
   type?: DocumentType;
   contentType?: string;
+  /** Content-type LIKE patterns, matched server-side as a case-insensitive OR (e.g. a file-type category spanning several content-types). */
+  contentTypes?: string[];
   name?: string;
   nameLike?: string;
   metadata?: { [key: string]: any };

--- a/src/app/models/file-type-filters.ts
+++ b/src/app/models/file-type-filters.ts
@@ -1,0 +1,131 @@
+/**
+ * File-type categories used by the quick file-type filter (folder toolbar) and the
+ * advanced search filters dialog.
+ *
+ * A category maps a human-friendly label + icon to one or more content-type LIKE
+ * patterns. The backend `ListFolderRequest.contentTypes` field matches them as a
+ * case-insensitive OR of LIKE clauses, so:
+ *   - `image/%`        matches every image content-type,
+ *   - `application/pdf` (no `%`) is an exact match,
+ *   - Office categories list both the legacy and the OOXML content-types (they don't
+ *     share a single prefix), so e.g. both `.doc` and `.docx` are matched.
+ *
+ * `SearchFilters.fileType` stores a category **id** (e.g. `'word'`), or `'any'` for
+ * no file-type restriction. Keep this the single source of truth for the mapping.
+ */
+export interface FileTypeCategory {
+  /** Stable id stored in SearchFilters.fileType. */
+  id: string;
+  /** ngx-translate key for the label. */
+  labelKey: string;
+  /** Material icon name. */
+  icon: string;
+  /** Icon color (hex) — matches the usual file-type color coding. */
+  color: string;
+  /** Content-type LIKE patterns (case-insensitive, `%` wildcard). */
+  patterns: string[];
+}
+
+export const ANY_FILE_TYPE = 'any';
+
+export const FILE_TYPE_CATEGORIES: FileTypeCategory[] = [
+  {
+    id: 'pdf',
+    labelKey: 'searchFilters.fileTypeOptions.pdfs',
+    icon: 'picture_as_pdf',
+    color: '#e53935',
+    patterns: ['application/pdf']
+  },
+  {
+    id: 'images',
+    labelKey: 'searchFilters.fileTypeOptions.images',
+    icon: 'image',
+    color: '#8e24aa',
+    patterns: ['image/%']
+  },
+  {
+    id: 'word',
+    labelKey: 'searchFilters.fileTypeOptions.documents',
+    icon: 'description',
+    color: '#1565c0',
+    patterns: [
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.oasis.opendocument.text',
+      'application/rtf'
+    ]
+  },
+  {
+    id: 'excel',
+    labelKey: 'searchFilters.fileTypeOptions.spreadsheets',
+    icon: 'table_chart',
+    color: '#2e7d32',
+    patterns: [
+      'application/vnd.ms-excel',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.oasis.opendocument.spreadsheet',
+      'text/csv'
+    ]
+  },
+  {
+    id: 'powerpoint',
+    labelKey: 'searchFilters.fileTypeOptions.presentations',
+    icon: 'slideshow',
+    color: '#ef6c00',
+    patterns: [
+      'application/vnd.ms-powerpoint',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'application/vnd.oasis.opendocument.presentation'
+    ]
+  },
+  {
+    id: 'text',
+    labelKey: 'searchFilters.fileTypeOptions.text',
+    icon: 'article',
+    color: '#546e7a',
+    patterns: ['text/%']
+  },
+  {
+    id: 'videos',
+    labelKey: 'searchFilters.fileTypeOptions.videos',
+    icon: 'movie',
+    color: '#d81b60',
+    patterns: ['video/%']
+  },
+  {
+    id: 'audio',
+    labelKey: 'searchFilters.fileTypeOptions.audio',
+    icon: 'music_note',
+    color: '#00897b',
+    patterns: ['audio/%']
+  },
+  {
+    id: 'archives',
+    labelKey: 'searchFilters.fileTypeOptions.archives',
+    icon: 'folder_zip',
+    color: '#6d4c41',
+    patterns: [
+      'application/zip',
+      'application/x-zip-compressed',
+      'application/x-tar',
+      'application/gzip',
+      'application/x-7z-compressed',
+      'application/x-rar-compressed',
+      'application/vnd.rar'
+    ]
+  }
+];
+
+const CATEGORY_BY_ID = new Map(FILE_TYPE_CATEGORIES.map(c => [c.id, c]));
+
+export function getFileTypeCategory(id?: string): FileTypeCategory | undefined {
+  if (!id || id === ANY_FILE_TYPE) {
+    return undefined;
+  }
+  return CATEGORY_BY_ID.get(id);
+}
+
+/** Content-type LIKE patterns for a category id, or `undefined` when no file-type filter applies. */
+export function getFileTypePatterns(id?: string): string[] | undefined {
+  return getFileTypeCategory(id)?.patterns;
+}

--- a/src/app/services/document-api.service.ts
+++ b/src/app/services/document-api.service.ts
@@ -28,6 +28,7 @@ import {
   PartialUploadResult,
   UploadErrorGroup
 } from '../models/document.models';
+import { getFileTypePatterns } from '../models/file-type-filters';
 import { environment } from '../../environments/environment';
 
 const LIST_FOLDER_QUERY = gql`
@@ -221,8 +222,9 @@ export class DocumentApiService {
       }
     }
 
-    if (filters.fileType && filters.fileType !== 'any') {
-      request.contentType = filters.fileType;
+    const contentTypePatterns = getFileTypePatterns(filters.fileType);
+    if (contentTypePatterns) {
+      request.contentTypes = contentTypePatterns;
     }
 
     if (filters.metadata && filters.metadata.length > 0) {

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -97,6 +97,7 @@
         "deleteSelected": "حذف العناصر المحددة",
         "gridView": "عرض الشبكة",
         "listView": "عرض القائمة",
+        "filterByType": "تصفية حسب النوع",
         "previousPage": "الصفحة السابقة",
         "nextPage": "الصفحة التالية",
         "firstPage": "الصفحة الأولى",
@@ -214,7 +215,12 @@
             "pdfs": "ملفات PDF",
             "images": "صور",
             "documents": "مستندات",
-            "spreadsheets": "جداول بيانات"
+            "spreadsheets": "جداول بيانات",
+            "presentations": "عروض تقديمية",
+            "text": "نص",
+            "videos": "مقاطع فيديو",
+            "audio": "صوت",
+            "archives": "أرشيفات"
         },
         "scope": "نطاق البحث",
         "scopeOptions": {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Ausgewählte Elemente löschen",
         "gridView": "Rasteransicht",
         "listView": "Listenansicht",
+        "filterByType": "Nach Typ filtern",
         "previousPage": "Vorherige Seite",
         "nextPage": "Nächste Seite",
         "firstPage": "Erste Seite",
@@ -214,7 +215,12 @@
             "pdfs": "PDFs",
             "images": "Bilder",
             "documents": "Dokumente",
-            "spreadsheets": "Tabellenkalkulationen"
+            "spreadsheets": "Tabellenkalkulationen",
+            "presentations": "Präsentationen",
+            "text": "Text",
+            "videos": "Videos",
+            "audio": "Audio",
+            "archives": "Archive"
         },
         "scope": "Suchbereich",
         "scopeOptions": {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Delete selected items",
         "gridView": "Grid view",
         "listView": "List view",
+        "filterByType": "Filter by type",
         "previousPage": "Previous page",
         "nextPage": "Next page",
         "firstPage": "First page",
@@ -214,7 +215,12 @@
             "pdfs": "PDFs",
             "images": "Images",
             "documents": "Documents",
-            "spreadsheets": "Spreadsheets"
+            "spreadsheets": "Spreadsheets",
+            "presentations": "Presentations",
+            "text": "Text",
+            "videos": "Videos",
+            "audio": "Audio",
+            "archives": "Archives"
         },
         "scope": "Search scope",
         "scopeOptions": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Eliminar elementos seleccionados",
         "gridView": "Vista de cuadrícula",
         "listView": "Vista de lista",
+        "filterByType": "Filtrar por tipo",
         "previousPage": "Página anterior",
         "nextPage": "Página siguiente",
         "firstPage": "Primera página",
@@ -214,7 +215,12 @@
             "pdfs": "PDFs",
             "images": "Imágenes",
             "documents": "Documentos",
-            "spreadsheets": "Hojas de cálculo"
+            "spreadsheets": "Hojas de cálculo",
+            "presentations": "Presentaciones",
+            "text": "Texto",
+            "videos": "Vídeos",
+            "audio": "Audio",
+            "archives": "Archivos"
         },
         "scope": "Alcance de búsqueda",
         "scopeOptions": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Supprimer les éléments sélectionnés",
         "gridView": "Vue en grille",
         "listView": "Vue en liste",
+        "filterByType": "Filtrer par type",
         "previousPage": "Page précédente",
         "nextPage": "Page suivante",
         "firstPage": "Première page",
@@ -214,7 +215,12 @@
             "pdfs": "PDF",
             "images": "Images",
             "documents": "Documents",
-            "spreadsheets": "Feuilles de calcul"
+            "spreadsheets": "Feuilles de calcul",
+            "presentations": "Présentations",
+            "text": "Texte",
+            "videos": "Vidéos",
+            "audio": "Audio",
+            "archives": "Archives"
         },
         "scope": "Portée de recherche",
         "scopeOptions": {

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Elimina elementi selezionati",
         "gridView": "Vista griglia",
         "listView": "Vista elenco",
+        "filterByType": "Filtra per tipo",
         "previousPage": "Pagina precedente",
         "nextPage": "Pagina successiva",
         "firstPage": "Prima pagina",
@@ -214,7 +215,12 @@
             "pdfs": "PDF",
             "images": "Immagini",
             "documents": "Documenti",
-            "spreadsheets": "Fogli di calcolo"
+            "spreadsheets": "Fogli di calcolo",
+            "presentations": "Presentazioni",
+            "text": "Testo",
+            "videos": "Video",
+            "audio": "Audio",
+            "archives": "Archivi"
         },
         "scope": "Ambito di ricerca",
         "scopeOptions": {

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Geselecteerde items verwijderen",
         "gridView": "Rasterweergave",
         "listView": "Lijstweergave",
+        "filterByType": "Filteren op type",
         "previousPage": "Vorige pagina",
         "nextPage": "Volgende pagina",
         "firstPage": "Eerste pagina",
@@ -214,7 +215,12 @@
             "pdfs": "PDF's",
             "images": "Afbeeldingen",
             "documents": "Documenten",
-            "spreadsheets": "Spreadsheets"
+            "spreadsheets": "Spreadsheets",
+            "presentations": "Presentaties",
+            "text": "Tekst",
+            "videos": "Video's",
+            "audio": "Audio",
+            "archives": "Archieven"
         },
         "scope": "Zoekbereik",
         "scopeOptions": {

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -97,6 +97,7 @@
         "deleteSelected": "Excluir itens selecionados",
         "gridView": "Vista de grade",
         "listView": "Vista de lista",
+        "filterByType": "Filtrar por tipo",
         "previousPage": "Página anterior",
         "nextPage": "Próxima página",
         "firstPage": "Primeira página",
@@ -214,7 +215,12 @@
             "pdfs": "PDFs",
             "images": "Imagens",
             "documents": "Documentos",
-            "spreadsheets": "Planilhas"
+            "spreadsheets": "Planilhas",
+            "presentations": "Apresentações",
+            "text": "Texto",
+            "videos": "Vídeos",
+            "audio": "Áudio",
+            "archives": "Arquivos"
         },
         "scope": "Âmbito da pesquisa",
         "scopeOptions": {


### PR DESCRIPTION
Add a color-coded file-type filter menu (PDF, Images, Documents, Spreadsheets, Presentations, Text, Videos, Audio, Archives) to the folder toolbar so a folder can be filtered by type in one click, without opening the advanced filters dialog. Shared file-type category definitions map each category to content-type patterns sent via the new ListFolderRequest. contentTypes field; the advanced dialog now uses the same categories. Active state shows the type icon + accent dot; clears via the breadcrumb chip. New i18n keys added to all 8 locales.