### PR TITLE
Modernize file explorer UI: icon-only actions, merged details panel, …

### DIFF
--- a/src/app/components/file-explorer/file-explorer.component.ts
+++ b/src/app/components/file-explorer/file-explorer.component.ts
@@ -90,6 +90,7 @@ type FolderConflictItem = BatchConflictItem & { parentId?: string };
         (moveSelected)="onMoveSelected()"
         (copySelected)="onCopySelected()"
         (deleteSelected)="onDeleteSelected()"
+        (detailsSelected)="onDetailsSelected()"
         (clearSelection)="onSelectAll(false)"
         (previousPage)="onPreviousPage()"
         (nextPage)="onNextPage()"
@@ -2274,5 +2275,12 @@ export class FileExplorerComponent extends FileOperationsComponent implements On
 
   onViewProperties(item: FileItem) {
     this.openMetadataPanel(item.id);
+  }
+
+  onDetailsSelected() {
+    const selected = this.selectedItems;
+    if (selected.length === 1) {
+      this.onViewProperties(selected[0]);
+    }
   }
 }

--- a/src/app/components/file-grid/file-grid.component.css
+++ b/src/app/components/file-grid/file-grid.component.css
@@ -368,6 +368,14 @@
   color: var(--text-secondary);
 }
 
+/* Invisible fixed-position anchor for the right-click context menu */
+.context-menu-anchor {
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}
+
 mat-paginator {
     flex-shrink: 0;
     background: var(--bg-primary) !important;

--- a/src/app/components/file-grid/file-grid.component.html
+++ b/src/app/components/file-grid/file-grid.component.html
@@ -55,13 +55,16 @@
                 </div>
             </div>
 
+            @if(showItemActions) {
             <div class="file-actions">
-                <button mat-icon-button (click)="onViewProperties(item); $event.stopPropagation()"
-                    [matTooltip]="'fileList.viewProperties' | translate"
-                    [attr.aria-label]="'fileList.viewPropertiesForItem' | translate:{name: item.name}">
-                    <mat-icon aria-hidden="true">info</mat-icon>
+                <button mat-icon-button class="item-menu-btn" [matMenuTriggerFor]="itemActionsMenu"
+                    (click)="onKebabClick($event, item)"
+                    [matTooltip]="'common.actions' | translate" aria-haspopup="menu"
+                    [attr.aria-label]="('common.actions' | translate) + ': ' + item.name">
+                    <mat-icon aria-hidden="true">more_vert</mat-icon>
                 </button>
             </div>
+            }
         </div>
         }
     </div>
@@ -72,4 +75,22 @@
         </div>
     </div>
 
+    <!-- Invisible anchor that positions the shared menu at the cursor on right-click -->
+    <div class="context-menu-anchor" [style.left.px]="contextMenuPosition.x" [style.top.px]="contextMenuPosition.y"
+        [matMenuTriggerFor]="itemActionsMenu" #contextMenuTrigger="matMenuTrigger" aria-hidden="true"></div>
+
+    <!-- Shared per-item actions menu (kebab + context menu) -->
+    <mat-menu #itemActionsMenu="matMenu" class="item-actions-menu">
+        <ng-template matMenuContent>
+            @for(action of itemActions; track action.id) {
+            @if(action.danger) {
+            <mat-divider></mat-divider>
+            }
+            <button mat-menu-item [class.danger-menu-item]="action.danger" (click)="onMenuAction(action.id)">
+                <mat-icon aria-hidden="true">{{ action.icon }}</mat-icon>
+                <span>{{ action.labelKey | translate }}</span>
+            </button>
+            }
+        </ng-template>
+    </mat-menu>
 </div>

--- a/src/app/components/file-grid/file-grid.component.ts
+++ b/src/app/components/file-grid/file-grid.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, Input, Output, inject } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, Output, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -7,7 +7,10 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { MatDividerModule } from '@angular/material/divider';
 import { FileItem } from '../../models/document.models';
+import { FileActionDescriptor, FileActionId, STANDARD_ITEM_ACTIONS } from '../../models/file-actions';
 import { FileIconService } from '../../services/file-icon.service';
 import { TouchDetectionService } from '../../services/touch-detection.service';
 
@@ -27,6 +30,8 @@ import { DropEvent } from '../../services/drag-drop.service';
     MatIconModule,
     MatCheckboxModule,
     MatTooltipModule,
+    MatMenuModule,
+    MatDividerModule,
     TranslateModule,
     FileDraggableDirective,
     FolderDropZoneDirective,
@@ -37,6 +42,7 @@ export class FileGridComponent {
   @Input() items: FileItem[] = [];
   @Input() fileOver: boolean = false;
   @Input() showFavoriteButton: boolean = true; // Control favorite button visibility
+  @Input() showItemActions: boolean = true; // Kebab + context menu (off in recycle bin)
   @Input() currentFolderId: string | null = null; // Current folder for drop zone validation
 
   @Output() itemClick = new EventEmitter<FileItem>();
@@ -97,9 +103,54 @@ export class FileGridComponent {
     this.selectionChange.emit({ item, selected });
   }
 
+  // ===== Per-item actions (kebab + right-click context menu) =====
+
+  @ViewChild('contextMenuTrigger') contextMenuTrigger?: MatMenuTrigger;
+  readonly itemActions: FileActionDescriptor[] = STANDARD_ITEM_ACTIONS;
+  contextMenuPosition = { x: 0, y: 0 };
+  /** Item the shared actions menu currently targets (set by kebab click or right-click) */
+  menuItem?: FileItem;
+
   onContextMenu(event: MouseEvent, item: FileItem) {
+    if (!this.showItemActions) return;
     event.preventDefault();
-    // Handle context menu
+    event.stopPropagation();
+    this.menuItem = item;
+    this.contextMenuPosition = { x: event.clientX, y: event.clientY };
+    this.contextMenuTrigger?.openMenu();
+  }
+
+  onKebabClick(event: Event, item: FileItem) {
+    event.stopPropagation();
+    this.menuItem = item;
+  }
+
+  onMenuAction(actionId: FileActionId) {
+    const item = this.menuItem;
+    if (!item) return;
+    switch (actionId) {
+      case 'open':
+        this.itemDoubleClick.emit(item);
+        break;
+      case 'download':
+        this.download.emit(item);
+        break;
+      case 'rename':
+        this.rename.emit(item);
+        break;
+      case 'move':
+        this.move.emit(item);
+        break;
+      case 'copy':
+        this.copy.emit(item);
+        break;
+      case 'details':
+        this.viewProperties.emit(item);
+        break;
+      case 'delete':
+        this.delete.emit(item);
+        break;
+    }
   }
 
   onRename(item: FileItem) {

--- a/src/app/components/file-list/file-list.component.css
+++ b/src/app/components/file-list/file-list.component.css
@@ -466,3 +466,10 @@ th.mat-header-cell {
   height: 18px;
   color: var(--text-secondary);
 }
+/* Invisible fixed-position anchor for the right-click context menu */
+.context-menu-anchor {
+  position: fixed;
+  width: 0;
+  height: 0;
+  pointer-events: none;
+}

--- a/src/app/components/file-list/file-list.component.html
+++ b/src/app/components/file-list/file-list.component.html
@@ -87,9 +87,11 @@
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef [attr.aria-label]="'common.actions' | translate"></th>
       <td mat-cell *matCellDef="let item" class="actions-cell">
-        <button mat-icon-button (click)="onViewProperties(item)" [matTooltip]="'fileList.viewProperties' | translate"
-          [attr.aria-label]="'fileList.viewPropertiesForItem' | translate:{name: item.name}">
-          <mat-icon aria-hidden="true">info</mat-icon>
+        <button mat-icon-button class="item-menu-btn" [matMenuTriggerFor]="itemActionsMenu"
+          (click)="onKebabClick($event, item)"
+          [matTooltip]="'common.actions' | translate" aria-haspopup="menu"
+          [attr.aria-label]="('common.actions' | translate) + ': ' + item.name">
+          <mat-icon aria-hidden="true">more_vert</mat-icon>
         </button>
       </td>
     </ng-container>
@@ -102,6 +104,7 @@
       [appFileDraggable]="row" [allItems]="items"
       [appFolderDropZone]="row.type === 'FOLDER' ? row : null"
       [currentFolderId]="currentFolderId"
+      (contextmenu)="onContextMenu($event, row)"
       (itemsDropped)="onItemsDropped($event)"></tr>
   </table>
   <div class="dropzone-overlay" [class.file-over]="fileOver">
@@ -110,4 +113,23 @@
       <p>{{ 'common.dropFilesHere' | translate }}</p>
     </div>
   </div>
+
+  <!-- Invisible anchor that positions the shared menu at the cursor on right-click -->
+  <div class="context-menu-anchor" [style.left.px]="contextMenuPosition.x" [style.top.px]="contextMenuPosition.y"
+    [matMenuTriggerFor]="itemActionsMenu" #contextMenuTrigger="matMenuTrigger" aria-hidden="true"></div>
+
+  <!-- Shared per-item actions menu (kebab + context menu) -->
+  <mat-menu #itemActionsMenu="matMenu" class="item-actions-menu">
+    <ng-template matMenuContent>
+      @for(action of itemActions; track action.id) {
+      @if(action.danger) {
+      <mat-divider></mat-divider>
+      }
+      <button mat-menu-item [class.danger-menu-item]="action.danger" (click)="onMenuAction(action.id)">
+        <mat-icon aria-hidden="true">{{ action.icon }}</mat-icon>
+        <span>{{ action.labelKey | translate }}</span>
+      </button>
+      }
+    </ng-template>
+  </mat-menu>
 </div>

--- a/src/app/components/file-list/file-list.component.ts
+++ b/src/app/components/file-list/file-list.component.ts
@@ -1,12 +1,15 @@
-import { Component, EventEmitter, HostListener, Input, Output, inject } from '@angular/core';
+import { Component, EventEmitter, HostListener, Input, Output, ViewChild, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatSortModule, Sort } from '@angular/material/sort';
 import { FileItem } from '../../models/document.models';
+import { FileActionDescriptor, FileActionId, STANDARD_ITEM_ACTIONS } from '../../models/file-actions';
 import { FileIconService } from '../../services/file-icon.service';
 import { TouchDetectionService } from '../../services/touch-detection.service';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -28,6 +31,8 @@ import { DropEvent } from '../../services/drag-drop.service';
     MatButtonModule,
     MatCheckboxModule,
     MatTooltipModule,
+    MatMenuModule,
+    MatDividerModule,
     TranslatePipe,
     FileDraggableDirective,
     FolderDropZoneDirective,
@@ -38,6 +43,7 @@ export class FileListComponent {
   @Input() items: FileItem[] = [];
   @Input() fileOver: boolean = false;
   @Input() showFavoriteButton: boolean = true; // Control favorite button visibility
+  @Input() showItemActions: boolean = true; // Kebab + context menu (off in recycle bin)
   @Input() sortBy: string = 'name';
   @Input() sortOrder: 'ASC' | 'DESC' = 'ASC';
   @Input() currentFolderId: string | null = null; // Current folder for drop zone validation
@@ -60,10 +66,15 @@ export class FileListComponent {
   focusedIndex = 0;
 
   get displayedColumns(): string[] {
+    const columns = ['drag', 'select'];
     if (this.showFavoriteButton) {
-      return ['drag', 'select', 'favorite', 'name', 'size', 'type', 'actions'];
+      columns.push('favorite');
     }
-    return ['drag', 'select', 'name', 'size', 'type', 'actions'];
+    columns.push('name', 'size', 'type');
+    if (this.showItemActions) {
+      columns.push('actions');
+    }
+    return columns;
   }
 
 
@@ -114,6 +125,56 @@ export class FileListComponent {
 
   onSelectionChange(item: FileItem, selected: boolean) {
     this.selectionChange.emit({ item, selected });
+  }
+
+  // ===== Per-item actions (kebab + right-click context menu) =====
+
+  @ViewChild('contextMenuTrigger') contextMenuTrigger?: MatMenuTrigger;
+  readonly itemActions: FileActionDescriptor[] = STANDARD_ITEM_ACTIONS;
+  contextMenuPosition = { x: 0, y: 0 };
+  /** Item the shared actions menu currently targets (set by kebab click or right-click) */
+  menuItem?: FileItem;
+
+  onContextMenu(event: MouseEvent, item: FileItem) {
+    if (!this.showItemActions) return;
+    event.preventDefault();
+    event.stopPropagation();
+    this.menuItem = item;
+    this.contextMenuPosition = { x: event.clientX, y: event.clientY };
+    this.contextMenuTrigger?.openMenu();
+  }
+
+  onKebabClick(event: Event, item: FileItem) {
+    event.stopPropagation();
+    this.menuItem = item;
+  }
+
+  onMenuAction(actionId: FileActionId) {
+    const item = this.menuItem;
+    if (!item) return;
+    switch (actionId) {
+      case 'open':
+        this.itemDoubleClick.emit(item);
+        break;
+      case 'download':
+        this.download.emit(item);
+        break;
+      case 'rename':
+        this.rename.emit(item);
+        break;
+      case 'move':
+        this.move.emit(item);
+        break;
+      case 'copy':
+        this.copy.emit(item);
+        break;
+      case 'details':
+        this.viewProperties.emit(item);
+        break;
+      case 'delete':
+        this.delete.emit(item);
+        break;
+    }
   }
 
   onSelectAll(selected: boolean) {

--- a/src/app/components/metadata-panel/metadata-panel.component.css
+++ b/src/app/components/metadata-panel/metadata-panel.component.css
@@ -1,13 +1,8 @@
-/* Overlay for dimming background when panel is open */
+/* Backdrop: only used for the mobile bottom-sheet presentation.
+   On desktop the panel is non-modal (like Drive's details pane) so the
+   user can keep browsing while it is open. */
 .metadata-panel-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.3);
-  z-index: 999;
-  transition: opacity 300ms ease-in-out;
+  display: none;
 }
 
 /* Allow drag events to pass through when external files are being dragged */
@@ -15,7 +10,7 @@
   pointer-events: none;
 }
 
-/* Right-side collapsible panel */
+/* Right-side details panel (desktop) */
 .metadata-panel {
   position: fixed;
   top: 0;
@@ -25,23 +20,41 @@
   max-width: 90vw;
   background-color: var(--bg-primary);
   box-shadow: -4px 0 20px rgba(0, 0, 0, 0.15);
+  border-left: 1px solid var(--border-color);
   z-index: 1000;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: transform 300ms ease-in-out;
+  animation: panelSlideInRight 250ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes panelSlideInRight {
+  from {
+    transform: translateX(100%);
+    opacity: 0.5;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }
 
 /* Panel Header */
 .panel-header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 24px;
+  padding: 16px 20px;
   background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%);
   color: white;
   box-shadow: var(--shadow-sm);
   flex-shrink: 0;
+}
+
+/* Sheet drag handle - visible only in the mobile bottom-sheet presentation */
+.panel-header .drag-handle {
+  display: none;
 }
 
 .header-content {
@@ -51,14 +64,14 @@
 }
 
 .header-icon {
-  font-size: 28px;
-  width: 28px;
-  height: 28px;
+  font-size: 24px;
+  width: 24px;
+  height: 24px;
 }
 
 .panel-header h2 {
   margin: 0;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 600;
   color: white;
 }
@@ -76,7 +89,7 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  padding: 24px;
+  padding: 16px 20px;
   background-color: var(--bg-secondary);
 }
 
@@ -119,60 +132,80 @@
   color: #dc2626;
 }
 
-/* Section Styling */
-.info-section,
-.metadata-section {
+/* Document hero */
+.doc-hero {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px;
   background-color: var(--bg-primary);
-  border-radius: 8px;
-  padding: 20px;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
   margin-bottom: 16px;
-  box-shadow: var(--shadow-sm);
+}
+
+.doc-hero-icon {
+  font-size: 40px;
+  width: 64px;
+  height: 64px;
+  min-width: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 14px;
+}
+
+.doc-hero-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.doc-hero-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  word-break: break-word;
+  margin-bottom: 8px;
+}
+
+.doc-hero-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.type-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background-color: var(--primary);
+  color: white;
+}
+
+.type-badge.type-folder {
+  background-color: var(--accent);
+}
+
+.size-chip {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background-color: var(--bg-tertiary);
+  color: var(--text-secondary);
   border: 1px solid var(--border-color);
 }
 
-.section-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
-  border-bottom: 2px solid var(--border-light);
-}
-
-.section-title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.section-header mat-icon {
-  color: var(--primary);
-  font-size: 22px;
-  width: 22px;
-  height: 22px;
-}
-
-.section-header h3 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-/* Info Content */
-.info-content {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  overflow: hidden;
-  max-width: 100%;
-}
-
+/* Info rows (SHA256) */
 .info-row {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  padding: 12px 0;
+  padding: 8px 0 12px;
   overflow: hidden;
   max-width: 100%;
 }
@@ -194,26 +227,7 @@
   overflow: hidden;
 }
 
-.type-badge {
-  display: inline-block;
-  padding: 4px 10px;
-  border-radius: 4px;
-  font-size: 12px;
-  font-weight: 500;
-  background-color: var(--primary);
-  color: white;
-}
-
-.type-badge.type-folder {
-  background-color: var(--accent);
-}
-
-
 /* SHA256 Hash Styling */
-.sha256-row {
-  padding: 12px 0;
-}
-
 .sha256-value {
   display: flex;
   align-items: center;
@@ -258,144 +272,211 @@
   color: var(--primary);
 }
 
-/* Metadata Content */
-.metadata-content {
-  margin-top: 12px;
-}
-
-/* Indicators */
-.saving-indicator {
+/* Metadata section */
+.metadata-section-header {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 12px;
-  padding: 12px;
-  background-color: #eff6ff;
-  border: 1px solid #bfdbfe;
-  border-radius: 6px;
-  color: #1e40af;
-  font-size: 13px;
-  margin-bottom: 12px;
+  margin: 8px 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--border-light);
 }
 
-.validation-warning {
+.metadata-section-header h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
+.add-metadata-btn {
+  height: 32px;
+  font-size: 13px;
+  border-radius: 8px;
+}
+
+.add-metadata-btn mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.metadata-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 24px 16px;
+  color: var(--text-secondary);
+  gap: 8px;
+}
+
+.metadata-empty mat-icon {
+  font-size: 36px;
+  width: 36px;
+  height: 36px;
+  opacity: 0.4;
+}
+
+.metadata-empty p {
+  font-size: 13px;
+  margin: 0;
+}
+
+/* Metadata rows: key | value (click-to-edit) | actions */
+.metadata-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.metadata-row {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px;
+  padding: 6px 10px;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  min-height: 44px;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.metadata-row:hover {
+  border-color: var(--primary-light, var(--primary));
+}
+
+.metadata-row.editing {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 20%, transparent);
+}
+
+.metadata-key {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  max-width: 35%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.metadata-value {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 8px;
+  cursor: text;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: background-color 150ms ease;
+}
+
+.metadata-value:hover {
+  background-color: var(--bg-tertiary);
+}
+
+.metadata-key-input,
+.metadata-value-input {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 6px 8px;
+  outline: none;
+}
+
+.metadata-key-input {
+  flex: 0 1 35%;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.metadata-key-input:focus,
+.metadata-value-input:focus {
+  border-color: var(--primary);
+}
+
+.metadata-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex-shrink: 0;
+}
+
+.row-action-btn {
+  width: 32px !important;
+  height: 32px !important;
+  line-height: 32px !important;
+}
+
+.row-action-btn mat-icon {
+  font-size: 17px;
+  width: 17px;
+  height: 17px;
+  color: var(--text-secondary);
+}
+
+.row-action-btn:hover mat-icon {
+  color: var(--primary);
+}
+
+.row-action-btn.danger:hover mat-icon {
+  color: #ef4444;
+}
+
+.row-action-btn.confirm mat-icon {
+  color: var(--primary);
+}
+
+.row-action-btn.confirm[disabled] mat-icon {
+  color: var(--text-tertiary);
+}
+
+/* Actions only revealed on hover on fine pointers; always visible on touch */
+@media (hover: hover) and (pointer: fine) {
+  .metadata-row:not(.add-row) .metadata-row-actions {
+    opacity: 0;
+    transition: opacity 150ms ease;
+  }
+
+  .metadata-row:hover .metadata-row-actions,
+  .metadata-row:focus-within .metadata-row-actions {
+    opacity: 1;
+  }
+}
+
+.metadata-add-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
   background-color: #fef2f2;
   border: 1px solid #fca5a5;
   border-radius: 6px;
   color: #dc2626;
   font-size: 13px;
-  margin-top: 12px;
 }
 
-.validation-warning mat-icon {
+.metadata-add-error mat-icon {
   color: #dc2626;
-  font-size: 20px;
-  width: 20px;
-  height: 20px;
-}
-
-.changes-indicator {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 12px;
-  background-color: #fef9c3;
-  border: 1px solid #fde047;
-  border-radius: 6px;
-  color: #854d0e;
-  font-size: 13px;
-  margin-top: 12px;
-}
-
-.changes-indicator mat-icon {
-  color: #854d0e;
-  font-size: 20px;
-  width: 20px;
-  height: 20px;
-}
-
-/* Panel Footer */
-.panel-footer {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 12px;
-  padding: 20px 24px;
-  background-color: var(--bg-primary);
-  border-top: 1px solid var(--border-color);
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.05);
-  flex-shrink: 0;
-}
-
-/* Cancel/Close Button */
-.panel-footer .cancel-btn {
-  display: flex !important;
-  align-items: center;
-  gap: 8px;
-  font-weight: 600 !important;
-  text-transform: none !important;
-  border-radius: 10px !important;
-  padding: 0 24px !important;
-  height: 44px !important;
-  font-size: 14px !important;
-  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1) !important;
-  border: 2px solid var(--border-color, #e2e8f0) !important;
-  color: var(--text-primary, #1e293b) !important;
-  background-color: var(--bg-primary, #ffffff) !important;
-}
-
-.panel-footer .cancel-btn:hover:not([disabled]) {
-  background-color: var(--bg-tertiary, #f1f5f9) !important;
-  border-color: var(--text-secondary, #64748b) !important;
-  transform: translateY(-1px);
-}
-
-.panel-footer .cancel-btn mat-icon {
   font-size: 18px;
   width: 18px;
   height: 18px;
-}
-
-/* Primary Button (Edit/Save) */
-.panel-footer .primary-btn {
-  display: flex !important;
-  align-items: center;
-  gap: 8px;
-  font-weight: 600 !important;
-  text-transform: none !important;
-  border-radius: 10px !important;
-  padding: 0 24px !important;
-  height: 44px !important;
-  font-size: 14px !important;
-  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1) !important;
-  background: linear-gradient(135deg, var(--primary) 0%, var(--primary-dark) 100%) !important;
-  color: white !important;
-  box-shadow: var(--shadow-md) !important;
-  border: none !important;
-}
-
-.panel-footer .primary-btn:hover:not([disabled]) {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg) !important;
-}
-
-.panel-footer .primary-btn[disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none !important;
-}
-
-.panel-footer .primary-btn mat-icon {
-  font-size: 18px;
-  width: 18px;
-  height: 18px;
-}
-
-.panel-footer .primary-btn mat-spinner {
-  margin-right: 4px;
 }
 
 /* Tab Styling */
@@ -569,24 +650,76 @@
   height: 14px;
 }
 
-/* Responsive Design */
+/* Mobile: bottom-sheet presentation with backdrop */
 @media (max-width: 768px) {
+  .metadata-panel-overlay {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    z-index: 999;
+    animation: overlayFadeIn 250ms ease-out;
+  }
+
   .metadata-panel {
+    top: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
     width: 100%;
     max-width: 100vw;
+    /* dvh keeps the sheet inside the visible viewport with dynamic browser
+       chrome; safe-area padding clears the phone's nav/home bar */
+    height: auto;
+    max-height: 85vh;
+    max-height: 85dvh;
+    border-left: none;
+    border-radius: 16px 16px 0 0;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.2);
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    animation: panelSlideUp 250ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .panel-header {
-    padding: 16px 20px;
+    border-radius: 16px 16px 0 0;
+    padding-top: 18px;
+  }
+
+  .panel-header .drag-handle {
+    display: block;
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 40px;
+    height: 4px;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 2px;
   }
 
   .panel-body {
-    padding: 16px;
+    padding: 12px 16px;
   }
+}
 
-  .info-section,
-  .metadata-section {
-    padding: 16px;
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes panelSlideUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
   }
 }
 
@@ -594,27 +727,4 @@
 button:focus-visible {
   outline: 2px solid var(--primary-light);
   outline-offset: 2px;
-}
-
-/* Animation keyframes */
-@keyframes slideIn {
-  from {
-    transform: translateX(100%);
-    opacity: 0;
-  }
-  to {
-    transform: translateX(0);
-    opacity: 1;
-  }
-}
-
-@keyframes slideOut {
-  from {
-    transform: translateX(0);
-    opacity: 1;
-  }
-  to {
-    transform: translateX(100%);
-    opacity: 0;
-  }
 }

--- a/src/app/components/metadata-panel/metadata-panel.component.html
+++ b/src/app/components/metadata-panel/metadata-panel.component.html
@@ -2,16 +2,16 @@
   <div class="metadata-panel-overlay"
     [ngClass]="{'drag-through': isExternalFileDragging}"
     (click)="onClose()"
-    [@slideInOut]="animationState"
     aria-hidden="true">
   </div>
 }
 
 @if (isOpen) {
-  <aside class="metadata-panel" [@slideInOut]="animationState" (click)="$event.stopPropagation()"
+  <aside class="metadata-panel" (click)="$event.stopPropagation()"
     role="complementary" [attr.aria-label]="'metadataPanel.description' | translate">
     <!-- Panel Header -->
     <div class="panel-header">
+      <div class="drag-handle" aria-hidden="true"></div>
       <div class="header-content">
         <mat-icon class="header-icon" aria-hidden="true">info</mat-icon>
         <h2 id="panel-title">{{ 'metadataPanel.title' | translate }}</h2>
@@ -41,91 +41,143 @@
       }
       @if(documentInfo && !loading) {
         <mat-tab-group [(selectedIndex)]="selectedTabIndex" (selectedIndexChange)="onTabChange($event)" class="panel-tabs">
-          <!-- General Tab -->
-          <mat-tab [attr.aria-label]="'metadataPanel.generalInfo' | translate">
+          <!-- Details Tab: general info + inline-editable metadata -->
+          <mat-tab [attr.aria-label]="'metadataPanel.details' | translate">
             <ng-template mat-tab-label>
               <mat-icon aria-hidden="true">info</mat-icon>
-              <span>{{ 'metadataPanel.general' | translate }}</span>
+              <span>{{ 'metadataPanel.details' | translate }}</span>
             </ng-template>
             <div class="tab-content">
-              <div class="info-content">
-                <div class="info-row">
-                  <span class="info-label">{{ 'common.name' | translate }}</span>
-                  <span class="info-value">{{ documentInfo.name }}</span>
-                </div>
-                <mat-divider></mat-divider>
-                <div class="info-row">
-                  <span class="info-label">{{ 'common.type' | translate }}</span>
-                  <span class="info-value">
+              <!-- Document hero -->
+              <div class="doc-hero">
+                <mat-icon class="doc-hero-icon" aria-hidden="true"
+                  [style.color]="documentColor"
+                  [style.background-color]="documentColor + '1a'">{{ documentIcon }}</mat-icon>
+                <div class="doc-hero-text">
+                  <div class="doc-hero-name" [title]="documentInfo.name">{{ documentInfo.name }}</div>
+                  <div class="doc-hero-meta">
                     <span class="type-badge" [class.type-folder]="documentInfo.type === 'FOLDER'">
                       @if (getFriendlyTypeKey(); as typeData) {
                         {{ typeData.key | translate: (typeData.params || {}) }}
                       }
                     </span>
+                    @if(documentInfo.size) {
+                      <span class="size-chip">{{ formatFileSize(documentInfo.size) }}</span>
+                    }
+                  </div>
+                </div>
+              </div>
+
+              @if(sha256Hash) {
+                <div class="info-row sha256-row">
+                  <span class="info-label">{{ 'metadataPanel.sha256' | translate }}</span>
+                  <span class="info-value sha256-value">
+                    <code class="sha256-hash" [matTooltip]="'metadataPanel.clickToCopy' | translate"
+                      (click)="copySha256ToClipboard()">{{ sha256Hash }}</code>
+                    <button mat-icon-button class="copy-button" (click)="copySha256ToClipboard()"
+                      [matTooltip]="'metadataPanel.copyToClipboard' | translate"
+                      [attr.aria-label]="'metadataPanel.copySha256' | translate">
+                      <mat-icon aria-hidden="true">content_copy</mat-icon>
+                    </button>
                   </span>
                 </div>
-                <mat-divider></mat-divider>
-                @if(documentInfo.size) {
-                  <div class="info-row">
-                    <span class="info-label">{{ 'common.size' | translate }}</span>
-                    <span class="info-value">{{ formatFileSize(documentInfo.size) }}</span>
-                  </div>
-                  <mat-divider></mat-divider>
+              }
+
+              <!-- Metadata: always visible, per-field inline editing -->
+              <div class="metadata-section-header">
+                <h3>{{ 'common.metadata' | translate }}</h3>
+                @if(!addingEntry) {
+                  <button mat-stroked-button class="add-metadata-btn" (click)="startAdd()"
+                    [attr.aria-label]="'metadataPanel.addMetadata' | translate">
+                    <mat-icon aria-hidden="true">add</mat-icon>
+                    <span>{{ 'metadataPanel.addMetadata' | translate }}</span>
+                  </button>
                 }
-                @if(sha256Hash) {
-                  <div class="info-row sha256-row">
-                    <span class="info-label">{{ 'metadataPanel.sha256' | translate }}</span>
-                    <span class="info-value sha256-value">
-                      <code class="sha256-hash" [matTooltip]="'metadataPanel.clickToCopy' | translate">{{ sha256Hash }}</code>
-                      <button mat-icon-button class="copy-button" (click)="copySha256ToClipboard()"
-                        [matTooltip]="'metadataPanel.copyToClipboard' | translate"
-                        [attr.aria-label]="'metadataPanel.copySha256' | translate">
-                        <mat-icon aria-hidden="true">content_copy</mat-icon>
+              </div>
+
+              @if(metadataEntries.length === 0 && !addingEntry) {
+                <div class="metadata-empty">
+                  <mat-icon aria-hidden="true">label_off</mat-icon>
+                  <p>{{ 'metadataEditor.noMetadata' | translate }}</p>
+                </div>
+              }
+
+              <div class="metadata-rows" role="list">
+                @for(entry of metadataEntries; track entry.key) {
+                  <div class="metadata-row" role="listitem" [class.editing]="editingKey === entry.key">
+                    <span class="metadata-key" [title]="entry.key">{{ entry.key }}</span>
+                    @if(editingKey === entry.key) {
+                      <input class="metadata-value-input" type="text" [(ngModel)]="editValue"
+                        (keydown.enter)="commitEdit(entry)" (keydown.escape)="cancelEdit()"
+                        (blur)="commitEdit(entry)" autofocus
+                        [attr.aria-label]="'metadataEditor.valueAriaLabel' | translate" />
+                    } @else {
+                      <button class="metadata-value" (click)="startEdit(entry)"
+                        [matTooltip]="'metadataPanel.clickToEdit' | translate"
+                        [attr.aria-label]="('metadataPanel.clickToEdit' | translate) + ': ' + entry.key">
+                        {{ entry.value }}
                       </button>
+                    }
+                    <span class="metadata-row-actions">
+                      @if(savingKey === entry.key) {
+                        <mat-spinner diameter="18" aria-hidden="true"></mat-spinner>
+                      } @else {
+                        <button mat-icon-button class="row-action-btn" (click)="startEdit(entry)"
+                          [matTooltip]="'common.rename' | translate"
+                          [attr.aria-label]="'metadataPanel.clickToEdit' | translate">
+                          <mat-icon aria-hidden="true">edit</mat-icon>
+                        </button>
+                        <button mat-icon-button class="row-action-btn danger" (click)="deleteEntry(entry)"
+                          [matTooltip]="'common.delete' | translate"
+                          [attr.aria-label]="('common.delete' | translate) + ' ' + entry.key">
+                          <mat-icon aria-hidden="true">delete</mat-icon>
+                        </button>
+                      }
                     </span>
                   </div>
-                  <mat-divider></mat-divider>
+                }
+
+                @if(addingEntry) {
+                  <div class="metadata-row add-row">
+                    <input class="metadata-key-input" type="text" [(ngModel)]="newKey"
+                      [placeholder]="'metadataEditor.keyPlaceholder' | translate"
+                      (keydown.enter)="commitAdd()" (keydown.escape)="cancelAdd()" autofocus
+                      [attr.aria-label]="'metadataEditor.keyAriaLabel' | translate" />
+                    <input class="metadata-value-input" type="text" [(ngModel)]="newValue"
+                      [placeholder]="'metadataEditor.valuePlaceholder' | translate"
+                      (keydown.enter)="commitAdd()" (keydown.escape)="cancelAdd()"
+                      [attr.aria-label]="'metadataEditor.valueAriaLabel' | translate" />
+                    <span class="metadata-row-actions">
+                      @if(savingKey && addingEntry) {
+                        <mat-spinner diameter="18" aria-hidden="true"></mat-spinner>
+                      } @else {
+                        <button mat-icon-button class="row-action-btn confirm" (click)="commitAdd()"
+                          [disabled]="!canCommitAdd" [matTooltip]="'common.save' | translate"
+                          [attr.aria-label]="'common.save' | translate">
+                          <mat-icon aria-hidden="true">check</mat-icon>
+                        </button>
+                        <button mat-icon-button class="row-action-btn" (click)="cancelAdd()"
+                          [matTooltip]="'common.cancel' | translate" [attr.aria-label]="'common.cancel' | translate">
+                          <mat-icon aria-hidden="true">close</mat-icon>
+                        </button>
+                      }
+                    </span>
+                  </div>
+                  @if(newEntryError) {
+                    <div class="metadata-add-error" role="alert">
+                      <mat-icon aria-hidden="true">error</mat-icon>
+                      {{ newEntryError | translate }}
+                    </div>
+                  }
                 }
               </div>
             </div>
           </mat-tab>
-          <!-- Metadata Tab -->
-          <mat-tab [attr.aria-label]="'common.metadata' | translate">
-            <ng-template mat-tab-label>
-              <mat-icon aria-hidden="true">label</mat-icon>
-              <span>{{ 'common.metadata' | translate }}</span>
-            </ng-template>
-            <div class="tab-content">
-              @if(saving) {
-                <div class="saving-indicator" role="status" aria-live="polite">
-                  <mat-spinner diameter="20" aria-hidden="true"></mat-spinner>
-                  <span>{{ 'metadataPanel.saving' | translate }}</span>
-                </div>
-              }
-              <div class="metadata-content">
-                <app-metadata-editor [metadata]="currentMetadata" [readonly]="!editMode" [showTitle]="false"
-                  (metadataChange)="onMetadataChange($event)" (valid)="onValidChange($event)">
-                </app-metadata-editor>
-              </div>
-              @if(editMode && !metadataValid) {
-                <div class="validation-warning" role="alert">
-                  <mat-icon aria-hidden="true">warning</mat-icon>
-                  {{ 'metadataPanel.fixErrors' | translate }}
-                </div>
-              }
-              @if(editMode && hasChanges) {
-                <div class="changes-indicator" role="status" aria-live="polite">
-                  <mat-icon aria-hidden="true">info</mat-icon>
-                  {{ 'metadataPanel.unsavedChanges' | translate }}
-                </div>
-              }
-            </div>
-          </mat-tab>
-          <!-- Audit Tab -->
+          <!-- Activity Tab: audit trail + file versions -->
           <mat-tab [attr.aria-label]="'metadataPanel.auditHistory' | translate">
             <ng-template mat-tab-label>
               <mat-icon aria-hidden="true">history</mat-icon>
-              <span>{{ 'metadataPanel.audit' | translate }}</span>
+              <span>{{ 'metadataPanel.activity' | translate }}</span>
             </ng-template>
             <div class="tab-content audit-tab">
               @if(auditLoading) {
@@ -190,39 +242,5 @@
         </mat-tab-group>
       }
     </div>
-    <!-- Panel Footer -->
-    @if (documentInfo) {
-      <div class="panel-footer">
-        @if(!editMode) {
-          <button mat-stroked-button class="cancel-btn" (click)="onClose()" [attr.aria-label]="'common.close' | translate">
-            <mat-icon aria-hidden="true">close</mat-icon>
-            <span>{{ 'common.close' | translate }}</span>
-          </button>
-          <button mat-raised-button class="primary-btn" (click)="toggleEditMode()"
-            [attr.aria-label]="'metadataPanel.editMetadata' | translate">
-            <mat-icon aria-hidden="true">edit</mat-icon>
-            <span>{{ 'metadataPanel.editMetadata' | translate }}</span>
-          </button>
-        } @else {
-          <button mat-stroked-button class="cancel-btn" (click)="toggleEditMode()" [disabled]="saving"
-            [attr.aria-label]="'metadataPanel.cancelEditing' | translate">
-            <mat-icon aria-hidden="true">close</mat-icon>
-            <span>{{ 'common.close' | translate }}</span>
-          </button>
-          <button mat-raised-button class="primary-btn" (click)="saveMetadata()" [disabled]="!canSave"
-            [attr.aria-label]="'metadataPanel.saveMetadata' | translate">
-            @if (saving) {
-              <mat-spinner diameter="18" aria-hidden="true"></mat-spinner>
-              <span>{{ 'metadataPanel.savingDots' | translate }}</span>
-            } @else {
-              <ng-container>
-                <mat-icon aria-hidden="true">save</mat-icon>
-                <span>{{ 'common.save' | translate }}</span>
-              </ng-container>
-            }
-          </button>
-        }
-      </div>
-    }
   </aside>
 }

--- a/src/app/components/metadata-panel/metadata-panel.component.ts
+++ b/src/app/components/metadata-panel/metadata-panel.component.ts
@@ -1,27 +1,31 @@
-import { Component, Input, Output, EventEmitter, OnInit, OnChanges, OnDestroy, ViewChild, inject } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnInit, OnChanges, OnDestroy, SimpleChanges, inject } from '@angular/core';
 import { NgClass } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTabsModule } from '@angular/material/tabs';
-import { MatDialog } from '@angular/material/dialog';
-import { trigger, state, style, transition, animate } from '@angular/animations';
 
-import { MetadataEditorComponent } from '../metadata-editor/metadata-editor.component';
 import { AuditVersionActionsComponent } from './audit-version-actions/audit-version-actions.component';
 import { DocumentApiService } from '../../services/document-api.service';
 import { DocumentVersionsService } from '../../services/document-versions.service';
 import { DragDropService } from '../../services/drag-drop.service';
 import { AuditLog, DocumentInfo } from '../../models/document.models';
 import { DocumentVersionInfo } from '../../models/document-versions.models';
-import { ConfirmDialogComponent, ConfirmDialogData } from '../../dialogs/confirm-dialog/confirm-dialog.component';
 import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 import { FileIconService } from '../../services/file-icon.service';
+
+/** A single metadata key/value shown in the inline editor */
+interface MetadataEntry {
+  key: string;
+  value: string;
+}
 
 @Component({
   selector: 'app-metadata-panel',
@@ -30,35 +34,20 @@ import { FileIconService } from '../../services/file-icon.service';
   styleUrls: ['./metadata-panel.component.css'],
   imports: [
     NgClass,
+    FormsModule,
     MatButtonModule,
     MatIconModule,
+    MatInputModule,
     MatProgressSpinnerModule,
     MatSnackBarModule,
     MatDividerModule,
     MatTooltipModule,
     MatTabsModule,
-    MetadataEditorComponent,
     AuditVersionActionsComponent,
     TranslatePipe
-],
-  animations: [
-    trigger('slideInOut', [
-      state('in', style({
-        transform: 'translateX(0)',
-        opacity: 1
-      })),
-      state('out', style({
-        transform: 'translateX(100%)',
-        opacity: 0
-      })),
-      transition('in => out', animate('300ms ease-in-out')),
-      transition('out => in', animate('300ms ease-in-out'))
-    ])
-  ]
+]
 })
 export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
-  @ViewChild(MetadataEditorComponent) metadataEditor?: MetadataEditorComponent;
-
   @Input() documentId?: string;
   @Input() isOpen: boolean = false;
   @Output() closePanel = new EventEmitter<void>();
@@ -66,18 +55,23 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   documentInfo?: DocumentInfo;
   loading: boolean = false;
-  saving: boolean = false;
   error?: string;
-  editMode: boolean = false;
-  metadataValid: boolean = true;
-  currentMetadata: { [key: string]: any } = {};
-  originalMetadata: { [key: string]: any } = {};
+  selectedTabIndex: number = 0;
+
+  // Inline metadata editing state (per-field, no global edit mode)
+  metadataEntries: MetadataEntry[] = [];
+  editingKey: string | null = null;
+  editValue: string = '';
+  savingKey: string | null = null;
+  addingEntry: boolean = false;
+  newKey: string = '';
+  newValue: string = '';
+  newEntryError?: string;
 
   // Audit
   auditLogs: AuditLog[] = [];
   auditLoading: boolean = false;
   auditError?: string;
-  selectedTabIndex: number = 0;
 
   // File versions (MinIO bucket versioning, flag-gated)
   versions: DocumentVersionInfo[] = [];
@@ -95,6 +89,8 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
 
   // System metadata keys that should not be editable
   private readonly SYSTEM_METADATA_KEYS = ['sha256'];
+
+  private readonly METADATA_KEY_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
   // MIME type to translation key mapping
   private readonly MIME_TYPE_KEYS: { [key: string]: string } = {
@@ -177,7 +173,6 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
   private dragDropService = inject(DragDropService);
   private fileIconService = inject(FileIconService);
   private snackBar = inject(MatSnackBar);
-  private dialog = inject(MatDialog);
   private translate = inject(TranslateService);
 
   constructor() { }
@@ -199,26 +194,30 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
     this.dragSubscription?.unsubscribe();
   }
 
-  ngOnChanges() {
-    if (this.documentId && this.isOpen && !this.documentInfo) {
-      this.loadDocumentInfo();
-    } else if (!this.isOpen) {
-      // Reset state when panel closes
+  ngOnChanges(changes: SimpleChanges) {
+    if (!this.isOpen) {
       this.resetState();
+      return;
+    }
+    // Load on open, and reload when the panel stays open but the target
+    // document changes (e.g. clicking Details on another item)
+    if (this.documentId && (changes['isOpen'] || changes['documentId'])) {
+      this.resetState();
+      this.loadDocumentInfo();
     }
   }
 
   private resetState() {
-    this.editMode = false;
     this.documentInfo = undefined;
-    this.currentMetadata = {};
-    this.originalMetadata = {};
     this.error = undefined;
     this.auditLogs = [];
     this.auditError = undefined;
     this.selectedTabIndex = 0;
     this.versions = [];
     this.versionIdByLog.clear();
+    this.metadataEntries = [];
+    this.cancelEdit();
+    this.cancelAdd();
   }
 
   get versioningEnabled(): boolean {
@@ -234,10 +233,7 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
     this.documentApi.getDocumentInfo(this.documentId, true).subscribe({
       next: (info) => {
         this.documentInfo = info;
-        // Filter out system metadata keys from editable metadata
-        const allMetadata = info.metadata || {};
-        this.originalMetadata = this.filterEditableMetadata(allMetadata);
-        this.currentMetadata = { ...this.originalMetadata };
+        this.buildMetadataEntries();
         this.loading = false;
       },
       error: (err) => {
@@ -248,18 +244,11 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
     });
   }
 
-
-  /**
-   * Filter out system metadata keys that should not be editable
-   */
-  private filterEditableMetadata(metadata: { [key: string]: any }): { [key: string]: any } {
-    const filtered: { [key: string]: any } = {};
-    for (const key of Object.keys(metadata)) {
-      if (!this.SYSTEM_METADATA_KEYS.includes(key)) {
-        filtered[key] = metadata[key];
-      }
-    }
-    return filtered;
+  private buildMetadataEntries() {
+    const metadata = this.documentInfo?.metadata || {};
+    this.metadataEntries = Object.keys(metadata)
+      .filter(key => !this.SYSTEM_METADATA_KEYS.includes(key))
+      .map(key => ({ key, value: String(metadata[key]) }));
   }
 
   /**
@@ -267,6 +256,16 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
    */
   get sha256Hash(): string | undefined {
     return this.documentInfo?.metadata?.['sha256'];
+  }
+
+  get documentIcon(): string {
+    if (!this.documentInfo) return 'description';
+    return this.fileIconService.getFileIcon(this.documentInfo.name, this.documentInfo.type);
+  }
+
+  get documentColor(): string {
+    if (!this.documentInfo) return 'var(--primary)';
+    return this.fileIconService.getFileColor(this.documentInfo.name, this.documentInfo.type);
   }
 
   getFriendlyTypeKey(): { key: string, params?: any } {
@@ -329,56 +328,124 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
     }
   }
 
-  onMetadataChange(metadata: { [key: string]: any }) {
-    this.currentMetadata = metadata;
+  // ===== Inline metadata editing (per-field save, no edit mode) =====
+
+  startEdit(entry: MetadataEntry) {
+    if (this.savingKey) return;
+    this.cancelAdd();
+    this.editingKey = entry.key;
+    this.editValue = entry.value;
   }
 
-  onValidChange(valid: boolean) {
-    this.metadataValid = valid;
+  cancelEdit() {
+    this.editingKey = null;
+    this.editValue = '';
   }
 
-  toggleEditMode() {
-    if (this.editMode) {
-      // Cancel editing - revert to original
-      this.currentMetadata = { ...this.originalMetadata };
-      this.editMode = false;
-    } else {
-      this.editMode = true;
-      // Switch to Metadata tab when entering edit mode
-      this.selectedTabIndex = 1;
+  commitEdit(entry: MetadataEntry) {
+    if (this.editingKey !== entry.key) return;
+    const newValue = this.editValue.trim();
+    if (!newValue || newValue === entry.value) {
+      this.cancelEdit();
+      return;
     }
+    if (!this.documentId) return;
+
+    this.savingKey = entry.key;
+    this.documentApi.updateDocumentMetadata(this.documentId, { [entry.key]: newValue }).subscribe({
+      next: () => {
+        entry.value = newValue;
+        this.syncLocalMetadata(entry.key, newValue);
+        this.savingKey = null;
+        this.cancelEdit();
+        this.snackBar.open(this.translate.instant('metadataPanel.saveSuccess'), this.translate.instant('common.close'), { duration: 2000 });
+        this.metadataSaved.emit();
+      },
+      error: () => {
+        this.savingKey = null;
+        this.snackBar.open(this.translate.instant('metadataPanel.saveFailed'), this.translate.instant('common.close'), { duration: 3000 });
+      }
+    });
   }
 
-  saveMetadata() {
-    if (!this.metadataValid || !this.documentInfo || !this.documentId) {
+  deleteEntry(entry: MetadataEntry) {
+    if (!this.documentId || this.savingKey) return;
+
+    this.savingKey = entry.key;
+    this.documentApi.deleteDocumentMetadata(this.documentId, [entry.key]).subscribe({
+      next: () => {
+        this.metadataEntries = this.metadataEntries.filter(e => e.key !== entry.key);
+        if (this.documentInfo?.metadata) {
+          delete this.documentInfo.metadata[entry.key];
+        }
+        this.savingKey = null;
+        this.snackBar.open(this.translate.instant('metadataPanel.keyDeleted', { key: entry.key }), this.translate.instant('common.close'), { duration: 2000 });
+        this.metadataSaved.emit();
+      },
+      error: () => {
+        this.savingKey = null;
+        this.snackBar.open(this.translate.instant('metadataPanel.saveFailed'), this.translate.instant('common.close'), { duration: 3000 });
+      }
+    });
+  }
+
+  startAdd() {
+    if (this.savingKey) return;
+    this.cancelEdit();
+    this.addingEntry = true;
+    this.newKey = '';
+    this.newValue = '';
+    this.newEntryError = undefined;
+  }
+
+  cancelAdd() {
+    this.addingEntry = false;
+    this.newKey = '';
+    this.newValue = '';
+    this.newEntryError = undefined;
+  }
+
+  get canCommitAdd(): boolean {
+    return !!this.newKey.trim() && !!this.newValue.trim() && !this.savingKey;
+  }
+
+  commitAdd() {
+    const key = this.newKey.trim();
+    const value = this.newValue.trim();
+    if (!key || !value || !this.documentId) return;
+
+    if (!this.METADATA_KEY_PATTERN.test(key)) {
+      this.newEntryError = 'metadataEditor.errors.invalidKeyFormat';
+      return;
+    }
+    const existingKeys = [...this.metadataEntries.map(e => e.key), ...this.SYSTEM_METADATA_KEYS];
+    if (existingKeys.some(k => k.toLowerCase() === key.toLowerCase())) {
+      this.newEntryError = 'metadataEditor.errors.duplicateKey';
       return;
     }
 
-    this.saving = true;
-
-    // Get the current metadata from the editor
-    const metadataToSave = this.metadataEditor?.getMetadata() || {};
-
-    this.documentApi.updateDocumentMetadata(this.documentId, metadataToSave).subscribe({
+    this.newEntryError = undefined;
+    this.savingKey = key;
+    this.documentApi.updateDocumentMetadata(this.documentId, { [key]: value }).subscribe({
       next: () => {
-        this.snackBar.open(this.translate.instant('metadataPanel.saveSuccess'), this.translate.instant('common.close'), { duration: 3000 });
-        this.originalMetadata = { ...metadataToSave };
-        this.currentMetadata = { ...metadataToSave };
-        this.editMode = false;
-        this.saving = false;
-
-        // Update the document info
-        if (this.documentInfo) {
-          this.documentInfo.metadata = metadataToSave;
-        }
-
+        this.metadataEntries.push({ key, value });
+        this.syncLocalMetadata(key, value);
+        this.savingKey = null;
+        this.cancelAdd();
+        this.snackBar.open(this.translate.instant('metadataPanel.saveSuccess'), this.translate.instant('common.close'), { duration: 2000 });
         this.metadataSaved.emit();
       },
-      error: (err) => {
+      error: () => {
+        this.savingKey = null;
         this.snackBar.open(this.translate.instant('metadataPanel.saveFailed'), this.translate.instant('common.close'), { duration: 3000 });
-        this.saving = false;
       }
     });
+  }
+
+  private syncLocalMetadata(key: string, value: string) {
+    if (this.documentInfo) {
+      this.documentInfo.metadata = { ...(this.documentInfo.metadata || {}), [key]: value };
+    }
   }
 
   formatFileSize(bytes?: number): string {
@@ -386,52 +453,15 @@ export class MetadataPanelComponent implements OnInit, OnChanges, OnDestroy {
     return this.fileIconService.getFileSize(bytes);
   }
 
-  formatDate(date?: string): string {
-    if (!date) return 'N/A';
-    return new Date(date).toLocaleString();
-  }
-
-  get hasChanges(): boolean {
-    return JSON.stringify(this.currentMetadata) !== JSON.stringify(this.originalMetadata);
-  }
-
-  get canSave(): boolean {
-    return this.editMode && this.metadataValid && this.hasChanges && !this.saving;
-  }
-
   onClose() {
-    if (this.editMode && this.hasChanges) {
-      const dialogData: ConfirmDialogData = {
-        title: this.translate.instant('metadataPanel.unsavedChangesTitle'),
-        message: this.translate.instant('metadataPanel.unsavedChangesMessage'),
-        details: this.translate.instant('metadataPanel.unsavedChangesDetails'),
-        type: 'warning',
-        confirmText: this.translate.instant('metadataPanel.discardChanges'),
-        cancelText: this.translate.instant('metadataPanel.keepEditing'),
-        icon: 'edit_off'
-      };
-      const dialogRef = this.dialog.open(ConfirmDialogComponent, {
-        width: '450px',
-        data: dialogData
-      });
-      dialogRef.afterClosed().subscribe(confirmed => {
-        if (confirmed) {
-          this.closePanel.emit();
-        }
-      });
-    } else {
-      this.closePanel.emit();
-    }
+    this.closePanel.emit();
   }
 
-  get animationState(): string {
-    return this.isOpen ? 'in' : 'out';
-  }
+  // ===== Activity (audit + versions) =====
 
-  // Audit methods
   onTabChange(index: number) {
     this.selectedTabIndex = index;
-    if (index === 2 && this.auditLogs.length === 0 && !this.auditLoading) {
+    if (index === 1 && this.auditLogs.length === 0 && !this.auditLoading) {
       this.loadAuditTrail();
     }
   }

--- a/src/app/components/search-results/search-results.component.html
+++ b/src/app/components/search-results/search-results.component.html
@@ -14,6 +14,7 @@
     (moveSelected)="onMoveSelected()"
     (copySelected)="onCopySelected()"
     (deleteSelected)="onDeleteSelected()"
+    (detailsSelected)="onDetailsSelected()"
     (clearSelection)="onSelectAll(false)"
   >
   </app-toolbar>

--- a/src/app/components/search-results/search-results.component.ts
+++ b/src/app/components/search-results/search-results.component.ts
@@ -270,6 +270,13 @@ export class SearchResultsComponent extends FileOperationsComponent implements O
     this.openMetadataPanel(item.id);
   }
 
+  onDetailsSelected() {
+    const selected = this.selectedItems;
+    if (selected.length === 1) {
+      this.onViewProperties(selected[0]);
+    }
+  }
+
   onToggleFavorite(item: FileItem) {
     const action = item.favorite ? 'remove from' : 'add to';
     this.documentApi.toggleFavorite(item.id).subscribe({

--- a/src/app/components/toolbar/toolbar.component.css
+++ b/src/app/components/toolbar/toolbar.component.css
@@ -91,27 +91,28 @@
   background-color: color-mix(in srgb, var(--primary) 10%, transparent);
 }
 
-/* Buttons */
-.upload-btn,
-.new-folder-btn {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  font-weight: 600;
-  text-transform: none;
-  border-radius: 10px;
-  padding: 0 24px;
+/* Create actions - icon-only buttons matching the selection bar */
+.create-action-btn {
+  width: 44px;
   height: 44px;
-  font-size: 14px;
-  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  border-radius: 10px;
+  color: var(--text-secondary);
+  transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
 }
 
-.upload-btn i,
-.new-folder-btn i {
-  margin-right: 2px;
+.create-action-btn mat-icon {
+  font-size: 26px;
+  width: 26px;
+  height: 26px;
 }
 
-.upload-btn {
+.create-action-btn:hover {
+  background-color: var(--bg-tertiary);
+  color: var(--primary);
+}
+
+/* Upload keeps the primary treatment so the main action stands out */
+.upload-icon-btn {
   background: linear-gradient(
     135deg,
     var(--primary) 0%,
@@ -121,51 +122,9 @@
   box-shadow: 0 2px 8px rgba(var(--primary-rgb, 99, 102, 241), 0.3);
 }
 
-.upload-btn:hover {
-  transform: translateY(-2px);
+.upload-icon-btn:hover {
+  color: white !important;
   box-shadow: 0 4px 16px rgba(var(--primary-rgb, 99, 102, 241), 0.4);
-}
-
-.new-folder-btn {
-  border: 2px solid var(--border-color);
-  color: var(--text-primary);
-  background-color: var(--bg-primary);
-}
-
-.new-folder-btn:hover {
-  background-color: var(--bg-tertiary);
-  border-color: var(--primary);
-  transform: translateY(-2px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-/* New Document Button */
-.new-document-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-weight: 600;
-  text-transform: none;
-  border-radius: 10px;
-  padding: 0 20px;
-  height: 44px;
-  font-size: 14px;
-  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
-  border: 2px solid var(--border-color);
-  color: var(--text-primary);
-  background-color: var(--bg-primary);
-}
-
-.new-document-btn:hover {
-  background-color: var(--bg-tertiary);
-  border-color: var(--primary);
-  transform: translateY(-2px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-}
-
-.new-document-btn .dropdown-icon {
-  margin-left: -4px;
-  font-size: 20px;
 }
 
 /* New Document Menu */
@@ -218,41 +177,38 @@
   color: var(--primary);
 }
 
-/* Selection actions */
+/* Selection actions - contextual bar with icon-only buttons */
 .selection-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
   flex-wrap: wrap;
 }
 
-.selection-actions button {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  text-transform: none;
-  border-radius: 6px;
-  padding: 0 16px;
-  height: 36px;
-  font-size: 14px;
-  transition: all 200ms cubic-bezier(0.4, 0, 0.2, 1);
+.selection-action-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  color: var(--text-secondary);
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
-.selection-actions button:hover {
+.selection-action-btn:hover {
   background-color: var(--bg-tertiary);
-  border-color: var(--primary);
-  transform: translateY(-2px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  color: var(--primary);
 }
 
-.selection-actions button[color="warn"]:hover {
-  border-color: var(--warn, #ef4444);
-  background-color: rgba(239, 68, 68, 0.08);
+.selection-action-btn.danger-action:hover {
+  background-color: rgba(239, 68, 68, 0.1);
+  color: var(--warn, #ef4444);
 }
 
-.selection-actions button i {
-  font-size: 14px;
-  margin-right: 2px;
+.selection-actions-divider {
+  width: 1px;
+  height: 24px;
+  background-color: var(--border-color);
+  margin: 0 4px;
+  flex-shrink: 0;
 }
 
 /* Pagination Controls */
@@ -438,13 +394,24 @@
   transform: scale(1.05);
 }
 
-/* Overflow menu button - hidden by default, shown on mobile */
-.overflow-menu-btn {
-  display: none;
+/* Sort menu button - lives in the right cluster next to the type filter */
+.sort-menu-btn {
   width: 44px;
   height: 44px;
-  min-width: 44px !important;
-  min-height: 44px !important;
+  border-radius: 10px;
+  color: var(--text-secondary);
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.sort-menu-btn:hover {
+  background-color: var(--bg-tertiary);
+  color: var(--primary);
+}
+
+/* Mobile copies of the sort/filter triggers (toolbar-right is hidden on mobile) */
+.mobile-sort-btn,
+.mobile-filter-btn {
+  display: none !important;
 }
 
 /* Action buttons desktop wrapper */
@@ -671,10 +638,6 @@
     padding: 14px 20px;
   }
 
-  .selection-actions button span {
-    font-size: 13px;
-  }
-
   .pagination-info {
     font-size: 13px;
   }
@@ -764,9 +727,10 @@
     display: none !important;
   }
 
-  /* Show overflow menu on mobile */
-  .overflow-menu-btn {
-    display: flex;
+  /* Show the mobile sort/filter triggers (their desktop twins live in the hidden toolbar-right) */
+  .mobile-sort-btn,
+  .mobile-filter-btn {
+    display: flex !important;
   }
 
   /* Show FAB on mobile */
@@ -863,16 +827,6 @@
   .selection-actions {
     flex-wrap: nowrap;
     gap: 8px;
-  }
-
-  .selection-actions button span {
-    display: none;
-  }
-
-  .selection-actions button {
-    min-width: 44px !important;
-    height: 44px !important;
-    padding: 0 12px;
   }
 }
 
@@ -1331,8 +1285,12 @@
   background-color: var(--bg-primary);
   border-radius: 16px 16px 0 0;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.15);
+  /* dvh keeps the sheet inside the visible viewport on mobile browsers with
+     dynamic chrome; the safe-area padding clears the phone's nav/home bar */
   max-height: 70vh;
+  max-height: 70dvh;
   overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   animation: slideUpBottomSheet 300ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
@@ -1584,14 +1542,6 @@
     font-size: 22px !important;
     width: 22px !important;
     height: 22px !important;
-  }
-
-  /* Overflow menu button - match other buttons */
-  .overflow-menu-btn {
-    width: 44px;
-    height: 44px;
-    min-width: 44px !important;
-    min-height: 44px !important;
   }
 
   /* View toggle - maintain proportion */

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -32,92 +32,80 @@
     @if(!hasSelection && !isSearchResultsPage) {
     <div class="action-buttons-desktop">
       @if(showUploadButton) {
-      <button mat-raised-button color="primary" class="upload-btn" (click)="onUploadFiles()"
+      <button mat-icon-button class="create-action-btn upload-icon-btn" (click)="onUploadFiles()"
+        [matTooltip]="'common.upload' | translate"
         [attr.aria-label]="'toolbar.uploadFiles' | translate">
         <mat-icon aria-hidden="true">cloud_upload</mat-icon>
-        <span>{{ 'common.upload' | translate }}</span>
       </button>
       }
 
       @if(showCreateFolderButton) {
-      <button mat-stroked-button class="new-folder-btn" (click)="onCreateFolder()"
+      <button mat-icon-button class="create-action-btn" (click)="onCreateFolder()"
+        [matTooltip]="'toolbar.newFolder' | translate"
         [attr.aria-label]="'toolbar.createNewFolder' | translate">
         <mat-icon aria-hidden="true">create_new_folder</mat-icon>
-        <span>{{ 'toolbar.newFolder' | translate }}</span>
       </button>
       }
 
       @if(showCreateDocumentButton && onlyOfficeEnabled) {
-      <button mat-stroked-button class="new-document-btn" [matMenuTriggerFor]="newDocumentMenu"
+      <button mat-icon-button class="create-action-btn" [matMenuTriggerFor]="newDocumentMenu"
+        [matTooltip]="'toolbar.newDocument' | translate"
         [attr.aria-label]="'toolbar.createNewDocument' | translate" aria-haspopup="menu">
         <mat-icon aria-hidden="true">note_add</mat-icon>
-        <span>{{ 'toolbar.newDocument' | translate }}</span>
-        <mat-icon class="dropdown-icon" aria-hidden="true">arrow_drop_down</mat-icon>
       </button>
       }
     </div>
 
-    <!-- Overflow menu for mobile -->
-    <button mat-icon-button class="overflow-menu-btn" [matMenuTriggerFor]="overflowMenu"
-      [attr.aria-label]="'toolbar.moreOptions' | translate" aria-haspopup="menu">
-      <mat-icon aria-hidden="true">more_vert</mat-icon>
+    <!-- Sort + filter triggers for mobile (toolbar-right is hidden there) -->
+    <button mat-icon-button class="sort-menu-btn mobile-sort-btn" [matMenuTriggerFor]="overflowMenu"
+      [matTooltip]="'toolbar.sortBy' | translate"
+      [attr.aria-label]="'toolbar.sortBy' | translate" aria-haspopup="menu">
+      <mat-icon aria-hidden="true">sort</mat-icon>
     </button>
-
-    <mat-menu #overflowMenu="matMenu" class="overflow-menu">
-      <div class="overflow-section-title">{{ 'toolbar.sortBy' | translate }}</div>
-      @for(option of sortOptions; track option.value) {
-      <button mat-menu-item (click)="onSortChange(option.value)" [class.active]="sortBy === option.value">
-        <span>{{ option.labelKey | translate }}</span>
-        @if(sortBy === option.value) {
-        <mat-icon aria-hidden="true">check</mat-icon>
-        }
-      </button>
+    @if(showTypeFilter) {
+    <button mat-icon-button class="type-filter-btn mobile-filter-btn" [class.active]="hasTypeFilter"
+      [matMenuTriggerFor]="fileTypeMenu"
+      [matTooltip]="(hasTypeFilter ? (activeCategory!.labelKey | translate) : ('toolbar.filterByType' | translate))"
+      [attr.aria-label]="'toolbar.filterByType' | translate" aria-haspopup="menu">
+      @if(activeCategory) {
+      <mat-icon aria-hidden="true" [style.color]="activeCategory.color">{{ activeCategory.icon }}</mat-icon>
+      <span class="type-filter-dot" aria-hidden="true"></span>
+      } @else {
+      <mat-icon aria-hidden="true">filter_alt</mat-icon>
       }
-      <mat-divider></mat-divider>
-      <button mat-menu-item (click)="toggleSortOrder()">
-        <mat-icon aria-hidden="true">{{ sortOrder === 'ASC' ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
-        <span>{{ sortOrder === 'ASC' ? ('toolbar.ascending' | translate) : ('toolbar.descending' | translate) }}</span>
-      </button>
-    </mat-menu>
+    </button>
+    }
     }
 
-    <!-- Selection actions - Desktop: all visible, Mobile: primary + more -->
+    <!-- Selection actions - Desktop: icon-only contextual bar, Mobile: actions button + sheet -->
     @if(hasSelection && showStandardSelectionActions) {
-    <!-- Desktop: Traditional horizontal layout -->
+    <!-- Desktop: icon buttons with tooltips + overflow menu -->
     <div class="selection-actions desktop-selection" role="group"
       [attr.aria-label]="'toolbar.managementToolbar' | translate">
-      @if(selectionCount === 1) {
-      <button mat-stroked-button (click)="onOpenSelected()"
-        [attr.aria-label]="'toolbar.openSelected' | translate">
-        <mat-icon aria-hidden="true">visibility</mat-icon>
-        <span>{{ 'common.open' | translate }}</span>
-      </button>
-      <button mat-stroked-button (click)="onRenameSelected()"
-        [attr.aria-label]="'toolbar.renameSelected' | translate">
-        <mat-icon aria-hidden="true">edit</mat-icon>
-        <span>{{ 'common.rename' | translate }}</span>
+      @for(action of primarySelectionActions; track action.id) {
+      <button mat-icon-button class="selection-action-btn" [class.danger-action]="action.danger"
+        (click)="onAction(action.id)"
+        [matTooltip]="action.labelKey | translate"
+        [attr.aria-label]="action.ariaKey | translate">
+        <mat-icon aria-hidden="true">{{ action.icon }}</mat-icon>
       </button>
       }
-      <button mat-stroked-button (click)="onDownloadSelected()"
-        [attr.aria-label]="'toolbar.downloadSelected' | translate">
-        <mat-icon aria-hidden="true">download</mat-icon>
-        <span>{{ 'common.download' | translate }}</span>
+      @if(overflowSelectionActions.length > 0) {
+      <div class="selection-actions-divider" aria-hidden="true"></div>
+      <button mat-icon-button class="selection-action-btn" [matMenuTriggerFor]="selectionOverflowMenu"
+        [matTooltip]="'toolbar.moreActions' | translate"
+        [attr.aria-label]="'toolbar.moreActions' | translate" aria-haspopup="menu">
+        <mat-icon aria-hidden="true">more_vert</mat-icon>
       </button>
-      <button mat-stroked-button (click)="onMoveSelected()"
-        [attr.aria-label]="'toolbar.moveSelected' | translate">
-        <mat-icon aria-hidden="true">open_with</mat-icon>
-        <span>{{ 'toolbar.move' | translate }}</span>
-      </button>
-      <button mat-stroked-button (click)="onCopySelected()"
-        [attr.aria-label]="'toolbar.copySelected' | translate">
-        <mat-icon aria-hidden="true">content_copy</mat-icon>
-        <span>{{ 'toolbar.copy' | translate }}</span>
-      </button>
-      <button mat-stroked-button color="warn" (click)="onDeleteSelected()"
-        [attr.aria-label]="'toolbar.deleteSelected' | translate">
-        <mat-icon aria-hidden="true">delete</mat-icon>
-        <span>{{ 'common.delete' | translate }}</span>
-      </button>
+      <mat-menu #selectionOverflowMenu="matMenu" class="selection-overflow-menu">
+        @for(action of overflowSelectionActions; track action.id) {
+        <button mat-menu-item (click)="onAction(action.id)" [attr.aria-label]="action.ariaKey | translate">
+          <mat-icon aria-hidden="true">{{ action.icon }}</mat-icon>
+          <span>{{ action.labelKey | translate }}</span>
+        </button>
+        }
+      </mat-menu>
+      }
     </div>
 
     <!-- Mobile: Actions button only -->
@@ -179,6 +167,15 @@
   }
 
   <div class="toolbar-right">
+    <!-- Sort menu (desktop) - grouped with filter and view controls -->
+    @if(!hasSelection && !isSearchResultsPage) {
+    <button mat-icon-button class="sort-menu-btn" [matMenuTriggerFor]="overflowMenu"
+      [matTooltip]="'toolbar.sortBy' | translate"
+      [attr.aria-label]="'toolbar.sortBy' | translate" aria-haspopup="menu">
+      <mat-icon aria-hidden="true">sort</mat-icon>
+    </button>
+    }
+
     <!-- Quick file-type filter (folder view only) -->
     @if(showTypeFilter) {
     <button mat-icon-button class="type-filter-btn" [class.active]="hasTypeFilter"
@@ -192,27 +189,6 @@
       <mat-icon aria-hidden="true">filter_alt</mat-icon>
       }
     </button>
-    <mat-menu #fileTypeMenu="matMenu" class="file-type-menu">
-      <button mat-menu-item class="file-type-option" (click)="onFileTypeSelected(ANY_FILE_TYPE)"
-        [class.active]="!hasTypeFilter">
-        <mat-icon aria-hidden="true">apps</mat-icon>
-        <span>{{ 'searchFilters.fileTypeOptions.any' | translate }}</span>
-        @if(!hasTypeFilter) {
-        <mat-icon class="option-check" aria-hidden="true">check</mat-icon>
-        }
-      </button>
-      <mat-divider></mat-divider>
-      @for(cat of fileTypeCategories; track cat.id) {
-      <button mat-menu-item class="file-type-option" (click)="onFileTypeSelected(cat.id)"
-        [class.active]="activeFileType === cat.id">
-        <mat-icon aria-hidden="true" [style.color]="cat.color">{{ cat.icon }}</mat-icon>
-        <span>{{ cat.labelKey | translate }}</span>
-        @if(activeFileType === cat.id) {
-        <mat-icon class="option-check" aria-hidden="true">check</mat-icon>
-        }
-      </button>
-      }
-    </mat-menu>
     }
 
     <!-- View toggle - always visible -->
@@ -358,69 +334,75 @@
       <h3>{{ 'common.actions' | translate }}</h3>
     </div>
 
-    <!-- Organize Actions -->
-    <div class="action-category" role="group" aria-labelledby="organize-heading">
-      <div class="action-category-title" id="organize-heading">{{ 'bottomSheet.organize' | translate }}</div>
+    @for(category of sheetCategories; track category.key; let last = $last) {
+    <div class="action-category" role="group" [attr.aria-labelledby]="category.key + '-heading'">
+      <div class="action-category-title" [class.danger-title]="category.key === 'danger'"
+        [id]="category.key + '-heading'">{{ category.titleKey | translate }}</div>
 
-      <button class="action-item" (click)="onActionSelected('open')" [disabled]="selectionCount !== 1" role="menuitem"
-        tabindex="0" [attr.aria-disabled]="selectionCount !== 1">
-        <mat-icon class="action-item-icon" aria-hidden="true">visibility</mat-icon>
-        <span class="action-item-label">{{ 'common.open' | translate }}</span>
-        @if(selectionCount !== 1) {
+      @for(action of sheetActionsFor(category.key); track action.id) {
+      <button class="action-item" [class.action-item-danger]="action.danger" (click)="onAction(action.id)"
+        [disabled]="!isActionEnabled(action)" role="menuitem" tabindex="0"
+        [attr.aria-disabled]="!isActionEnabled(action)">
+        <mat-icon class="action-item-icon" aria-hidden="true">{{ action.icon }}</mat-icon>
+        <span class="action-item-label">{{ (action.sheetLabelKey || action.labelKey) | translate }}</span>
+        @if(!isActionEnabled(action)) {
         <span class="action-item-meta">{{ 'bottomSheet.oneItemOnly' | translate }}</span>
         }
-      </button>
-
-      <button class="action-item" (click)="onActionSelected('move')" role="menuitem" tabindex="0">
-        <mat-icon class="action-item-icon" aria-hidden="true">open_with</mat-icon>
-        <span class="action-item-label">{{ 'bottomSheet.moveTo' | translate }}</span>
-      </button>
-
-      <button class="action-item" (click)="onActionSelected('copy')" role="menuitem" tabindex="0">
-        <mat-icon class="action-item-icon" aria-hidden="true">content_copy</mat-icon>
-        <span class="action-item-label">{{ 'bottomSheet.copyTo' | translate }}</span>
-      </button>
-
-      <button class="action-item" (click)="onActionSelected('rename')" [disabled]="selectionCount !== 1" role="menuitem"
-        tabindex="0" [attr.aria-disabled]="selectionCount !== 1">
-        <mat-icon class="action-item-icon" aria-hidden="true">edit</mat-icon>
-        <span class="action-item-label">{{ 'common.rename' | translate }}</span>
-        @if(selectionCount !== 1) {
-        <span class="action-item-meta">{{ 'bottomSheet.oneItemOnly' | translate }}</span>
-        }
-      </button>
-    </div>
-
-    <mat-divider></mat-divider>
-
-    <!-- Share & Download Actions -->
-    <div class="action-category" role="group" aria-labelledby="share-heading">
-      <div class="action-category-title" id="share-heading">{{ 'bottomSheet.shareAndDownload' | translate }}</div>
-
-      <button class="action-item" (click)="onActionSelected('download')" role="menuitem" tabindex="0">
-        <mat-icon class="action-item-icon" aria-hidden="true">download</mat-icon>
-        <span class="action-item-label">{{ 'common.download' | translate }}</span>
-      </button>
-    </div>
-
-    <mat-divider></mat-divider>
-
-    <!-- Danger Zone -->
-    <div class="action-category" role="group" aria-labelledby="danger-heading">
-      <div class="action-category-title danger-title" id="danger-heading">
-        {{ 'bottomSheet.dangerZone' | translate }}
-      </div>
-
-      <button class="action-item action-item-danger" (click)="onActionSelected('delete')" role="menuitem" tabindex="0">
-        <mat-icon class="action-item-icon" aria-hidden="true">delete</mat-icon>
-        <span class="action-item-label">{{ 'common.delete' | translate }}</span>
+        @if(action.id === 'delete') {
         <span class="action-item-meta">{{ selectionCount === 1 ? ('bottomSheet.item' | translate:{count: 1}) :
           ('bottomSheet.items' | translate:{count: selectionCount}) }}</span>
+        }
       </button>
+      }
     </div>
+    @if(!last) {
+    <mat-divider></mat-divider>
+    }
+    }
   </div>
 </div>
 }
+
+<!-- File-type Filter Menu (shared between the desktop right cluster and the mobile trigger) -->
+<mat-menu #fileTypeMenu="matMenu" class="file-type-menu">
+  <button mat-menu-item class="file-type-option" (click)="onFileTypeSelected(ANY_FILE_TYPE)"
+    [class.active]="!hasTypeFilter">
+    <mat-icon aria-hidden="true">apps</mat-icon>
+    <span>{{ 'searchFilters.fileTypeOptions.any' | translate }}</span>
+    @if(!hasTypeFilter) {
+    <mat-icon class="option-check" aria-hidden="true">check</mat-icon>
+    }
+  </button>
+  <mat-divider></mat-divider>
+  @for(cat of fileTypeCategories; track cat.id) {
+  <button mat-menu-item class="file-type-option" (click)="onFileTypeSelected(cat.id)"
+    [class.active]="activeFileType === cat.id">
+    <mat-icon aria-hidden="true" [style.color]="cat.color">{{ cat.icon }}</mat-icon>
+    <span>{{ cat.labelKey | translate }}</span>
+    @if(activeFileType === cat.id) {
+    <mat-icon class="option-check" aria-hidden="true">check</mat-icon>
+    }
+  </button>
+  }
+</mat-menu>
+
+<!-- Sort Menu (shared between the desktop right cluster and the mobile trigger) -->
+<mat-menu #overflowMenu="matMenu" class="overflow-menu">
+  <div class="overflow-section-title">{{ 'toolbar.sortBy' | translate }}</div>
+  @for(option of sortOptions; track option.value) {
+  <button mat-menu-item (click)="onSortChange(option.value)" [class.active]="sortBy === option.value">
+    <span>{{ option.labelKey | translate }}</span>
+    @if(sortBy === option.value) {
+    <mat-icon aria-hidden="true">check</mat-icon>
+    }
+  </button>
+  }
+  <mat-divider></mat-divider>
+  <button mat-menu-item (click)="toggleSortOrder()">
+    <mat-icon aria-hidden="true">{{ sortOrder === 'ASC' ? 'arrow_upward' : 'arrow_downward' }}</mat-icon>
+    <span>{{ sortOrder === 'ASC' ? ('toolbar.ascending' | translate) : ('toolbar.descending' | translate) }}</span>
+  </button>
+</mat-menu>
 
 <!-- New Document Menu (shared between desktop and mobile) -->
 <mat-menu #newDocumentMenu="matMenu" class="new-document-menu">

--- a/src/app/components/toolbar/toolbar.component.ts
+++ b/src/app/components/toolbar/toolbar.component.ts
@@ -10,6 +10,7 @@ import { AppConfig } from '../../config/app.config';
 import { TranslatePipe } from '@ngx-translate/core';
 import { DocumentTemplateType } from '../../models/document.models';
 import { ANY_FILE_TYPE, FILE_TYPE_CATEGORIES, FileTypeCategory, getFileTypeCategory } from '../../models/file-type-filters';
+import { FileActionCategory, FileActionDescriptor, FileActionId, SHEET_CATEGORIES, STANDARD_SELECTION_ACTIONS } from '../../models/file-actions';
 
 @Component({
   selector: 'app-toolbar',
@@ -57,6 +58,7 @@ export class ToolbarComponent {
   @Output() moveSelected = new EventEmitter<void>();
   @Output() copySelected = new EventEmitter<void>();
   @Output() deleteSelected = new EventEmitter<void>();
+  @Output() detailsSelected = new EventEmitter<void>();
   @Output() clearSelection = new EventEmitter<void>();
   @Output() sortChange = new EventEmitter<{ sortBy: string, sortOrder: 'ASC' | 'DESC' }>();
   @Output() createDocument = new EventEmitter<DocumentTemplateType>();
@@ -254,8 +256,28 @@ export class ToolbarComponent {
     }
   }
 
-  onActionSelected(action: string): void {
-    // Execute action based on type
+  // Selection actions are descriptor-driven so downstream forks can extend
+  // the array instead of forking the templates.
+  readonly selectionActionDefs: FileActionDescriptor[] = STANDARD_SELECTION_ACTIONS;
+  readonly sheetCategories = SHEET_CATEGORIES;
+
+  isActionEnabled(action: FileActionDescriptor): boolean {
+    return !action.singleOnly || this.selectionCount === 1;
+  }
+
+  get primarySelectionActions(): FileActionDescriptor[] {
+    return this.selectionActionDefs.filter(a => a.placement === 'primary' && this.isActionEnabled(a));
+  }
+
+  get overflowSelectionActions(): FileActionDescriptor[] {
+    return this.selectionActionDefs.filter(a => a.placement === 'overflow' && this.isActionEnabled(a));
+  }
+
+  sheetActionsFor(category: FileActionCategory): FileActionDescriptor[] {
+    return this.selectionActionDefs.filter(a => a.category === category);
+  }
+
+  onAction(action: FileActionId): void {
     switch (action) {
       case 'open':
         if (this.selectionCount === 1) {
@@ -273,6 +295,11 @@ export class ToolbarComponent {
           this.onRenameSelected();
         }
         break;
+      case 'details':
+        if (this.selectionCount === 1) {
+          this.detailsSelected.emit();
+        }
+        break;
       case 'download':
         this.onDownloadSelected();
         break;
@@ -286,13 +313,6 @@ export class ToolbarComponent {
   }
 
   getAvailableActionsCount(): number {
-    // Count available actions in bottom sheet
-    // Base actions: move, copy, download, delete = 4
-    // Open + Rename: only if 1 item selected
-    let count = 4;
-    if (this.selectionCount === 1) {
-      count += 2; // Add open and rename
-    }
-    return count;
+    return this.selectionActionDefs.filter(a => this.isActionEnabled(a)).length;
   }
 }

--- a/src/app/models/file-actions.ts
+++ b/src/app/models/file-actions.ts
@@ -1,0 +1,55 @@
+/**
+ * Descriptors driving every surface that renders file/folder actions:
+ * the contextual selection toolbar (icon buttons + overflow menu), the
+ * mobile selection bottom sheet, and the per-item kebab/context menus.
+ *
+ * Downstream forks (openfilz-web-ee) extend the UI by contributing extra
+ * descriptors instead of forking the templates.
+ */
+export type FileActionId = 'open' | 'rename' | 'download' | 'move' | 'copy' | 'delete' | 'details';
+
+export type FileActionCategory = 'organize' | 'transfer' | 'danger';
+
+export interface FileActionDescriptor {
+  id: FileActionId;
+  icon: string;
+  labelKey: string;
+  /** Label used in the mobile bottom sheet when it differs from labelKey (e.g. "Move to...") */
+  sheetLabelKey?: string;
+  ariaKey: string;
+  category: FileActionCategory;
+  /** 'primary' renders as an icon button in the contextual bar; 'overflow' goes to the "more" menu */
+  placement: 'primary' | 'overflow';
+  /** Action only applies to a single selected item */
+  singleOnly?: boolean;
+  danger?: boolean;
+}
+
+/** Selection-bar actions (order defines rendering order per placement/category) */
+export const STANDARD_SELECTION_ACTIONS: FileActionDescriptor[] = [
+  { id: 'download', icon: 'download', labelKey: 'common.download', ariaKey: 'toolbar.downloadSelected', category: 'transfer', placement: 'primary' },
+  { id: 'move', icon: 'drive_file_move', labelKey: 'toolbar.move', sheetLabelKey: 'bottomSheet.moveTo', ariaKey: 'toolbar.moveSelected', category: 'organize', placement: 'primary' },
+  { id: 'copy', icon: 'content_copy', labelKey: 'toolbar.copy', sheetLabelKey: 'bottomSheet.copyTo', ariaKey: 'toolbar.copySelected', category: 'organize', placement: 'primary' },
+  { id: 'delete', icon: 'delete', labelKey: 'common.delete', ariaKey: 'toolbar.deleteSelected', category: 'danger', placement: 'primary', danger: true },
+  { id: 'open', icon: 'visibility', labelKey: 'common.open', ariaKey: 'toolbar.openSelected', category: 'organize', placement: 'overflow', singleOnly: true },
+  { id: 'rename', icon: 'edit', labelKey: 'common.rename', ariaKey: 'toolbar.renameSelected', category: 'organize', placement: 'overflow', singleOnly: true },
+  { id: 'details', icon: 'info', labelKey: 'common.details', ariaKey: 'fileList.viewProperties', category: 'organize', placement: 'overflow', singleOnly: true },
+];
+
+/** Per-item kebab / right-click context menu actions (order = menu order) */
+export const STANDARD_ITEM_ACTIONS: FileActionDescriptor[] = [
+  { id: 'open', icon: 'visibility', labelKey: 'common.open', ariaKey: 'toolbar.openSelected', category: 'organize', placement: 'primary' },
+  { id: 'download', icon: 'download', labelKey: 'common.download', ariaKey: 'toolbar.downloadSelected', category: 'transfer', placement: 'primary' },
+  { id: 'rename', icon: 'edit', labelKey: 'common.rename', ariaKey: 'toolbar.renameSelected', category: 'organize', placement: 'primary' },
+  { id: 'move', icon: 'drive_file_move', labelKey: 'toolbar.move', ariaKey: 'toolbar.moveSelected', category: 'organize', placement: 'primary' },
+  { id: 'copy', icon: 'content_copy', labelKey: 'toolbar.copy', ariaKey: 'toolbar.copySelected', category: 'organize', placement: 'primary' },
+  { id: 'details', icon: 'info', labelKey: 'common.details', ariaKey: 'fileList.viewProperties', category: 'organize', placement: 'primary' },
+  { id: 'delete', icon: 'delete', labelKey: 'common.delete', ariaKey: 'toolbar.deleteSelected', category: 'danger', placement: 'primary', danger: true },
+];
+
+/** Bottom-sheet category grouping (order = sheet order) */
+export const SHEET_CATEGORIES: { key: FileActionCategory; titleKey: string }[] = [
+  { key: 'organize', titleKey: 'bottomSheet.organize' },
+  { key: 'transfer', titleKey: 'bottomSheet.shareAndDownload' },
+  { key: 'danger', titleKey: 'bottomSheet.dangerZone' },
+];

--- a/src/app/pages/favorites/favorites.component.html
+++ b/src/app/pages/favorites/favorites.component.html
@@ -4,7 +4,7 @@
     [pageIndex]="pageIndex" [pageSize]="pageSize" [totalItems]="totalItems" [showUploadButton]="false"
     [showCreateFolderButton]="false" (viewModeChange)="onViewModeChange($event)" (renameSelected)="onRenameSelected()"
     (downloadSelected)="onDownloadSelected()" (moveSelected)="onMoveSelected()" (copySelected)="onCopySelected()"
-    (deleteSelected)="onDeleteSelected()" (clearSelection)="onClearSelection()" (previousPage)="onPreviousPage()"
+    (deleteSelected)="onDeleteSelected()" (detailsSelected)="onDetailsSelected()" (clearSelection)="onClearSelection()" (previousPage)="onPreviousPage()"
     (nextPage)="onNextPage()" (pageSizeChange)="onPageSizeChange($event)" [sortBy]="sortBy" [sortOrder]="sortOrder"
     (sortChange)="onSortChange($event)">
 

--- a/src/app/pages/favorites/favorites.component.ts
+++ b/src/app/pages/favorites/favorites.component.ts
@@ -137,6 +137,13 @@ export class FavoritesComponent extends FileOperationsComponent implements OnIni
     this.openMetadataPanel(item.id);
   }
 
+  onDetailsSelected() {
+    const selected = this.selectedItems;
+    if (selected.length === 1) {
+      this.onViewProperties(selected[0]);
+    }
+  }
+
   override onItemDoubleClick(item: FileItem) {
     // Clear the pending single-click timeout
     if (this.clickTimeout) {

--- a/src/app/pages/recycle-bin/recycle-bin.component.html
+++ b/src/app/pages/recycle-bin/recycle-bin.component.html
@@ -63,7 +63,7 @@
 
     @if (!loading && items.length > 0) {
     @if (viewMode === 'grid') {
-    <app-file-grid [items]="items" [showFavoriteButton]="false" (itemClick)="onItemClick($event)"
+    <app-file-grid [items]="items" [showFavoriteButton]="false" [showItemActions]="false" (itemClick)="onItemClick($event)"
       (itemDoubleClick)="onItemDoubleClick($event)" (selectionChange)="onSelectionChange($event)"
       (toggleFavorite)="onToggleFavorite($event)" (rename)="onRenameItem($event)" (download)="onDownloadItem($event)"
       (move)="onMoveItem($event)" (copy)="onCopyItem($event)" (delete)="onDeleteItem($event)">
@@ -71,7 +71,7 @@
     }
 
     @if (viewMode === 'list') {
-    <app-file-list [items]="items" [showFavoriteButton]="false" (itemClick)="onItemClick($event)"
+    <app-file-list [items]="items" [showFavoriteButton]="false" [showItemActions]="false" (itemClick)="onItemClick($event)"
       (itemDoubleClick)="onItemDoubleClick($event)" (selectionChange)="onSelectionChange($event)"
       (selectAll)="onSelectAll($event)" (toggleFavorite)="onToggleFavorite($event)" (rename)="onRenameItem($event)"
       (download)="onDownloadItem($event)" (move)="onMoveItem($event)" (copy)="onCopyItem($event)"

--- a/src/app/services/document-api.service.ts
+++ b/src/app/services/document-api.service.ts
@@ -608,6 +608,11 @@ export class DocumentApiService {
     return this.http.patch<ElementInfo>(`${this.baseUrl}/documents/${documentId}/metadata`, { metadataToUpdate: metadata });
   }
 
+  deleteDocumentMetadata(documentId: string, metadataKeys: string[]): Observable<void> {
+    // PATCH merges keys, so removing one requires the dedicated DELETE endpoint
+    return this.http.delete<void>(`${this.baseUrl}/documents/${documentId}/metadata`, { body: { metadataKeysToDelete: metadataKeys } });
+  }
+
   // Dashboard operations
   getDashboardStatistics(): Observable<DashboardStatistics> {
     return this.http.get<DashboardStatistics>(`${this.baseUrl}/dashboard/statistics`);

--- a/src/assets/styles/global_styles.css
+++ b/src/assets/styles/global_styles.css
@@ -756,3 +756,22 @@ a,
 .theme-dark .drop-zone-hover {
   background-color: rgba(129, 140, 248, 0.2) !important;
 }
+/* Per-item actions menu (kebab + right-click context menu) */
+.item-actions-menu .mat-mdc-menu-item .mat-icon {
+  color: var(--text-secondary);
+}
+
+.item-actions-menu .danger-menu-item,
+.item-actions-menu .danger-menu-item .mat-icon,
+.item-actions-menu .danger-menu-item .mdc-list-item__primary-text {
+  color: #ef4444 !important;
+}
+
+.item-actions-menu .danger-menu-item:hover {
+  background-color: rgba(239, 68, 68, 0.08);
+}
+
+/* Selection overflow menu shares the same look */
+.selection-overflow-menu .mat-mdc-menu-item .mat-icon {
+  color: var(--text-secondary);
+}

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -38,7 +38,8 @@
         "dropFilesHere": "اسحب الملفات هنا للرفع",
         "view": "عرض",
         "expand": "توسيع",
-        "minimize": "تصغير"
+        "minimize": "تصغير",
+        "details": "التفاصيل"
     },
     "languages": {
         "en": "English",
@@ -118,7 +119,8 @@
             "excel": "جدول بيانات Excel",
             "powerpoint": "عرض PowerPoint تقديمي",
             "text": "ملف نصي"
-        }
+        },
+        "moreActions": "المزيد من الإجراءات"
     },
     "sortOptions": {
         "date": "التاريخ",
@@ -269,7 +271,13 @@
         "keepEditing": "متابعة التعديل",
         "hashCopied": "تم نسخ هاش SHA256 إلى الحافظة",
         "copyFailed": "فشل النسخ إلى الحافظة",
-        "saveSuccess": "تم حفظ المستند بنجاح"
+        "saveSuccess": "تم حفظ المستند بنجاح",
+        "details": "التفاصيل",
+        "activity": "النشاط",
+        "addMetadata": "إضافة",
+        "clickToEdit": "انقر للتعديل",
+        "keyDeleted": "تمت إزالة \"{{key}}\"",
+        "saveFailed": "فشل حفظ البيانات الوصفية"
     },
     "metadataEditor": {
         "clearAll": "مسح الكل",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -38,7 +38,8 @@
         "value": "Wert",
         "dropFilesHere": "Dateien zum Hochladen hier ablegen",
         "expand": "Erweitern",
-        "minimize": "Minimieren"
+        "minimize": "Minimieren",
+        "details": "Details"
     },
     "languages": {
         "en": "English",
@@ -118,7 +119,8 @@
             "excel": "Excel-Tabelle",
             "powerpoint": "PowerPoint-Präsentation",
             "text": "Textdatei"
-        }
+        },
+        "moreActions": "Weitere Aktionen"
     },
     "sortOptions": {
         "date": "Datum",
@@ -269,7 +271,13 @@
         "keepEditing": "Bearbeitung fortsetzen",
         "hashCopied": "SHA256-Hash in die Zwischenablage kopiert",
         "copyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
-        "saveSuccess": "Dokument erfolgreich gespeichert"
+        "saveSuccess": "Dokument erfolgreich gespeichert",
+        "details": "Details",
+        "activity": "Aktivität",
+        "addMetadata": "Hinzufügen",
+        "clickToEdit": "Zum Bearbeiten klicken",
+        "keyDeleted": "\"{{key}}\" entfernt",
+        "saveFailed": "Metadaten konnten nicht gespeichert werden"
     },
     "metadataEditor": {
         "clearAll": "Alles löschen",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -38,7 +38,8 @@
         "value": "Value",
         "dropFilesHere": "Drop files here to upload",
         "expand": "Expand",
-        "minimize": "Minimize"
+        "minimize": "Minimize",
+        "details": "Details"
     },
     "languages": {
         "en": "English",
@@ -118,7 +119,8 @@
             "excel": "Excel Spreadsheet",
             "powerpoint": "PowerPoint Presentation",
             "text": "Text File"
-        }
+        },
+        "moreActions": "More actions"
     },
     "sortOptions": {
         "date": "Date",
@@ -269,7 +271,13 @@
         "keepEditing": "Keep editing",
         "hashCopied": "SHA256 hash copied to clipboard",
         "copyFailed": "Failed to copy to clipboard",
-        "saveSuccess": "Document saved successfully"
+        "saveSuccess": "Document saved successfully",
+        "details": "Details",
+        "activity": "Activity",
+        "addMetadata": "Add",
+        "clickToEdit": "Click to edit",
+        "keyDeleted": "\"{{key}}\" removed",
+        "saveFailed": "Failed to save metadata"
     },
     "metadataEditor": {
         "clearAll": "Clear All",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -38,7 +38,8 @@
         "value": "Valor",
         "dropFilesHere": "Suelte archivos aquí para subir",
         "expand": "Expandir",
-        "minimize": "Minimizar"
+        "minimize": "Minimizar",
+        "details": "Detalles"
     },
     "languages": {
         "en": "Inglés",
@@ -118,7 +119,8 @@
             "excel": "Hoja de cálculo de Excel",
             "powerpoint": "Presentación de PowerPoint",
             "text": "Archivo de texto"
-        }
+        },
+        "moreActions": "Más acciones"
     },
     "sortOptions": {
         "date": "Fecha",
@@ -269,7 +271,13 @@
         "keepEditing": "Seguir editando",
         "hashCopied": "Hash SHA256 copiado al portapapeles",
         "copyFailed": "Error al copiar al portapapeles",
-        "saveSuccess": "Documento guardado con éxito"
+        "saveSuccess": "Documento guardado con éxito",
+        "details": "Detalles",
+        "activity": "Actividad",
+        "addMetadata": "Añadir",
+        "clickToEdit": "Haz clic para editar",
+        "keyDeleted": "\"{{key}}\" eliminado",
+        "saveFailed": "Error al guardar los metadatos"
     },
     "metadataEditor": {
         "clearAll": "Limpiar todo",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -38,7 +38,8 @@
         "value": "Valeur",
         "dropFilesHere": "Déposez les fichiers ici pour téléverser",
         "expand": "Développer",
-        "minimize": "Réduire"
+        "minimize": "Réduire",
+        "details": "Détails"
     },
     "languages": {
         "en": "English",
@@ -118,7 +119,8 @@
             "excel": "Feuille de calcul Excel",
             "powerpoint": "Présentation PowerPoint",
             "text": "Fichier texte"
-        }
+        },
+        "moreActions": "Plus d'actions"
     },
     "sortOptions": {
         "date": "Date",
@@ -269,7 +271,13 @@
         "keepEditing": "Continuer l'édition",
         "hashCopied": "Hachage SHA256 copié dans le presse-papiers",
         "copyFailed": "Échec de la copie dans le presse-papiers",
-        "saveSuccess": "Document enregistré avec succès"
+        "saveSuccess": "Document enregistré avec succès",
+        "details": "Détails",
+        "activity": "Activité",
+        "addMetadata": "Ajouter",
+        "clickToEdit": "Cliquer pour modifier",
+        "keyDeleted": "« {{key}} » supprimé",
+        "saveFailed": "Échec de l'enregistrement des métadonnées"
     },
     "metadataEditor": {
         "clearAll": "Tout effacer",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -38,7 +38,8 @@
         "value": "Valore",
         "dropFilesHere": "Trascina i file qui per il caricamento",
         "expand": "Espandi",
-        "minimize": "Minimizza"
+        "minimize": "Minimizza",
+        "details": "Dettagli"
     },
     "languages": {
         "en": "Inglese",
@@ -118,7 +119,8 @@
             "excel": "Foglio di calcolo Excel",
             "powerpoint": "Presentazione PowerPoint",
             "text": "File di testo"
-        }
+        },
+        "moreActions": "Altre azioni"
     },
     "sortOptions": {
         "date": "Data",
@@ -269,7 +271,13 @@
         "keepEditing": "Continua a modificare",
         "hashCopied": "Hash SHA256 copiato negli appunti",
         "copyFailed": "Copia negli appunti fallita",
-        "saveSuccess": "Documento salvato con successo"
+        "saveSuccess": "Documento salvato con successo",
+        "details": "Dettagli",
+        "activity": "Attività",
+        "addMetadata": "Aggiungi",
+        "clickToEdit": "Clicca per modificare",
+        "keyDeleted": "\"{{key}}\" rimosso",
+        "saveFailed": "Impossibile salvare i metadati"
     },
     "metadataEditor": {
         "clearAll": "Pulisci Tutto",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -38,7 +38,8 @@
         "dropFilesHere": "Sleep bestanden hierheen om te uploaden",
         "view": "Bekijken",
         "expand": "Uitvouwen",
-        "minimize": "Minimaliseren"
+        "minimize": "Minimaliseren",
+        "details": "Details"
     },
     "languages": {
         "en": "Engels",
@@ -118,7 +119,8 @@
             "excel": "Excel-spreadsheet",
             "powerpoint": "PowerPoint-presentatie",
             "text": "Tekstbestand"
-        }
+        },
+        "moreActions": "Meer acties"
     },
     "sortOptions": {
         "date": "Datum",
@@ -269,7 +271,13 @@
         "keepEditing": "Blijven bewerken",
         "hashCopied": "SHA256-hash gekopieerd naar klembord",
         "copyFailed": "Kopiëren naar klembord mislukt",
-        "saveSuccess": "Document succesvol opgeslagen"
+        "saveSuccess": "Document succesvol opgeslagen",
+        "details": "Details",
+        "activity": "Activiteit",
+        "addMetadata": "Toevoegen",
+        "clickToEdit": "Klik om te bewerken",
+        "keyDeleted": "\"{{key}}\" verwijderd",
+        "saveFailed": "Opslaan van metadata mislukt"
     },
     "metadataEditor": {
         "clearAll": "Alles wissen",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -38,7 +38,8 @@
         "dropFilesHere": "Solte os arquivos aqui para fazer upload",
         "view": "Visualizar",
         "expand": "Expandir",
-        "minimize": "Minimizar"
+        "minimize": "Minimizar",
+        "details": "Detalhes"
     },
     "languages": {
         "en": "Inglês",
@@ -118,7 +119,8 @@
             "excel": "Planilha Excel",
             "powerpoint": "Apresentação PowerPoint",
             "text": "Arquivo de texto"
-        }
+        },
+        "moreActions": "Mais ações"
     },
     "sortOptions": {
         "date": "Data",
@@ -269,7 +271,13 @@
         "keepEditing": "Continuar a editar",
         "hashCopied": "Hash SHA256 copiado para a área de transferência",
         "copyFailed": "Falha ao copiar para a área de transferência",
-        "saveSuccess": "Documento guardado com sucesso"
+        "saveSuccess": "Documento guardado com sucesso",
+        "details": "Detalhes",
+        "activity": "Atividade",
+        "addMetadata": "Adicionar",
+        "clickToEdit": "Clique para editar",
+        "keyDeleted": "\"{{key}}\" removido",
+        "saveFailed": "Falha ao salvar os metadados"
     },
     "metadataEditor": {
         "clearAll": "Limpar Tudo",


### PR DESCRIPTION
…kebab/context menus

Redesigns the selection toolbar as an icon-only contextual action bar (icons + tooltips, overflow menu for single-item actions) driven by a shared action descriptor array, so downstream forks can extend it without forking templates. Same descriptors power a new per-item kebab menu and right-click context menu on grid/list rows, and the mobile selection bottom sheet.

Merges the metadata-panel's General + Metadata tabs into one Details view with always-visible, click-to-edit-per-field metadata (no more Edit/Save mode), and fixes a real bug along the way: field removal was PATCHing the remaining map instead of calling the dedicated DELETE endpoint, so removed keys silently survived on the backend.

Adds a responsive bottom-sheet presentation for the details panel and toolbar selection sheet on mobile (dvh + safe-area-inset-bottom), and surfaces the sort/filter triggers next to the breadcrumb on small screens where the desktop right-hand toolbar cluster is hidden.