### PR TITLE
feat(explorer): explain the single-click vs checkbox selection rule v…

### DIFF
--- a/src/app/components/file-grid/file-grid.component.html
+++ b/src/app/components/file-grid/file-grid.component.html
@@ -16,6 +16,8 @@
                 (click)="$event.stopPropagation()">
                 <mat-checkbox [checked]="item.selected"
                     [attr.aria-label]="'fileList.selectItem' | translate:{name: item.name}"
+                    [matTooltip]="'fileList.selectionHint' | translate"
+                    matTooltipPosition="right" [matTooltipShowDelay]="400"
                     (change)="onSelectionChange(item, $event.checked)">
                 </mat-checkbox>
             </div>

--- a/src/app/components/file-list/file-list.component.html
+++ b/src/app/components/file-list/file-list.component.html
@@ -20,7 +20,9 @@
       </th>
       <td mat-cell *matCellDef="let item">
         <mat-checkbox [checked]="item.selected" (change)="onSelectionChange(item, $event.checked)"
-          [attr.aria-label]="'fileList.selectItem' | translate:{name: item.name}">
+          [attr.aria-label]="'fileList.selectItem' | translate:{name: item.name}"
+          [matTooltip]="'fileList.selectionHint' | translate"
+          matTooltipPosition="right" [matTooltipShowDelay]="400">
         </mat-checkbox>
       </td>
     </ng-container>

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -130,6 +130,7 @@
         "filesTable": "قائمة الملفات والمجلدات",
         "selectAll": "تحديد الكل",
         "selectItem": "تحديد {{name}}",
+        "selectionHint": "حدد المربع لاختيار عدة عناصر. النقر البسيط يحدد هذا العنصر فقط ويفتح خصائصه.",
         "select": "تحديد",
         "folderDetail": "مجلد: {{name}}",
         "fileDetail": "ملف: {{name}}",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -130,6 +130,7 @@
         "filesTable": "Datei- und Ordnerliste",
         "selectAll": "Alle Dateien auswählen",
         "selectItem": "{{name}} auswählen",
+        "selectionHint": "Ankreuzen, um mehrere Elemente auszuwählen. Ein einfacher Klick wählt nur dieses aus und öffnet seine Eigenschaften.",
         "select": "Auswählen",
         "folderDetail": "Ordner: {{name}}",
         "fileDetail": "Datei: {{name}}",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -130,6 +130,7 @@
         "filesTable": "Files and folders list",
         "selectAll": "Select all files",
         "selectItem": "Select {{name}}",
+        "selectionHint": "Tick to select several items. A single click selects only this one and opens its properties.",
         "select": "Select",
         "folderDetail": "Folder: {{name}}",
         "fileDetail": "File: {{name}}",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -130,6 +130,7 @@
         "filesTable": "Lista de archivos y carpetas",
         "selectAll": "Seleccionar todos los archivos",
         "selectItem": "Seleccionar {{name}}",
+        "selectionHint": "Marca para seleccionar varios elementos. Un solo clic selecciona solo este y abre sus propiedades.",
         "select": "Seleccionar",
         "folderDetail": "Carpeta: {{name}}",
         "fileDetail": "Archivo: {{name}}",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -130,6 +130,7 @@
         "filesTable": "Liste des fichiers et dossiers",
         "selectAll": "Sélectionner tous les fichiers",
         "selectItem": "Sélectionner {{name}}",
+        "selectionHint": "Cochez pour sélectionner plusieurs éléments. Un simple clic ne sélectionne que celui-ci et ouvre ses propriétés.",
         "select": "Sélectionner",
         "folderDetail": "Dossier : {{name}}",
         "fileDetail": "Fichier : {{name}}",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -130,6 +130,7 @@
         "filesTable": "Elenco file e cartelle",
         "selectAll": "Seleziona tutti i file",
         "selectItem": "Seleziona {{name}}",
+        "selectionHint": "Spunta per selezionare più elementi. Un clic singolo seleziona solo questo e apre le sue proprietà.",
         "select": "Seleziona",
         "folderDetail": "Cartella: {{name}}",
         "fileDetail": "File: {{name}}",

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -130,6 +130,7 @@
         "filesTable": "Lijst met bestanden en mappen",
         "selectAll": "Alle bestanden selecteren",
         "selectItem": "Selecteer {{name}}",
+        "selectionHint": "Vink aan om meerdere items te selecteren. Eén klik selecteert alleen dit item en opent de eigenschappen.",
         "select": "Selecteren",
         "folderDetail": "Map: {{name}}",
         "fileDetail": "Bestand: {{name}}",

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -130,6 +130,7 @@
         "filesTable": "Lista de arquivos e pastas",
         "selectAll": "Selecionar todos os arquivos",
         "selectItem": "Selecionar {{name}}",
+        "selectionHint": "Marque para selecionar vários itens. Um único clique seleciona apenas este e abre as suas propriedades.",
         "select": "Selecionar",
         "folderDetail": "Pasta: {{name}}",
         "fileDetail": "Arquivo: {{name}}",


### PR DESCRIPTION
…ia a checkbox tooltip

Hovering an item's selection checkbox now shows a tooltip clarifying that the checkbox is for multi-select, while a plain single click selects only that item and opens its properties. Added the fileList.selectionHint string to all 8 locales.