### PR TITLE
fix(explorer): toolbar "Details" (i) button reliably opens the proper…

### DIFF
--- a/src/app/components/base/file-operations.component.ts
+++ b/src/app/components/base/file-operations.component.ts
@@ -337,6 +337,10 @@ export abstract class FileOperationsComponent implements OnInit {
     if (target.closest('.metadata-panel-overlay')) return;
     if (target.closest('.file-item') || target.closest('.file-row')) return;
     if (target.closest('.cdk-overlay-container')) return;
+    // The toolbar is a control surface for the current selection (its "Details"
+    // button opens this very panel). Treat toolbar clicks as inside, so opening
+    // the panel from the toolbar isn't immediately undone by this same click.
+    if (target.closest('app-toolbar')) return;
     this.attemptCloseMetadataPanel();
   }
 


### PR DESCRIPTION
…ties panel

The document:click outside-close handler was closing the panel on the same click that the toolbar's Details button used to open it (the toolbar is outside the panel, so the bubbled click immediately undid the open). Treat the toolbar as a control surface for the current selection — clicks within app-toolbar no longer close the panel. Empty-area / sidebar clicks still do.