### PR TITLE
fix(metadata-panel): stop Activity tab collapsing to a single audit e…

### DIFF
--- a/src/app/components/metadata-panel/metadata-panel.component.html
+++ b/src/app/components/metadata-panel/metadata-panel.component.html
@@ -204,7 +204,7 @@
                   </div>
                 } @else {
                   <div class="audit-timeline" role="list" [attr.aria-label]="'metadataPanel.auditLogs' | translate">
-                    @for(log of auditLogs; track log.id) {
+                    @for(log of auditLogs; track $index) {
                       <div class="audit-entry" [class]="'audit-' + getAuditActionColor(log.action)" role="listitem">
                         <div class="audit-icon">
                           <mat-icon aria-hidden="true">{{ getAuditActionIcon(log.action) }}</mat-icon>


### PR DESCRIPTION
…ntry

The audit timeline used @for(log of auditLogs; track log.id), but every audit-trail entry comes back with id=null (the endpoint never selects an id column). Angular @for renders one node per distinct track key, so all versions collapsed onto the null key and only the latest survived (e.g. after a content replace, "Document Uploaded" v1 disappeared, leaving only "Content Replaced" v2).

Track by $index instead (the list is already sorted by the backend).