### PR TITLE
feat(helm): podSecurityContext seam for the web pod (OpenShift support)

### DIFF
--- a/deploy/helm/openfilz-web/templates/deployment.yaml
+++ b/deploy/helm/openfilz-web/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       {{- with (.Values.tolerations | default (dig "tolerations" list (.Values.global | default dict))) }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: web
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ include "openfilz-web.imageTag" . }}"

--- a/deploy/helm/openfilz-web/values.yaml
+++ b/deploy/helm/openfilz-web/values.yaml
@@ -89,6 +89,12 @@ openshift:
       caCertificate: ""
       destinationCACertificate: ""
 
+# Pod securityContext ({} = cluster/image defaults). OpenShift: the entrypoint
+# writes ngx-env.js into the nginx html dir, which needs the image's root user
+# — set runAsUser: 0 (with an SCC granted) so the pod doesn't land on the
+# `restricted` SCC's random UID.
+podSecurityContext: {}
+
 resources:
   requests: { cpu: 25m, memory: 64Mi }
   limits: { memory: 128Mi }


### PR DESCRIPTION
The entrypoint writes ngx-env.js into the nginx html dir, which needs the image root user - on OpenShift the pod must REQUEST it (runAsUser: 0, with an SCC granted) or it lands on the restricted SCC with a random UID and the write fails. New value `podSecurityContext` ({} = unchanged behaviour); consumed by the openfilz-ce OpenShift example values. Ships with the next chart release (>= 1.2.13).